### PR TITLE
Port most astronomical functions and tests to java

### DIFF
--- a/java/adhan/src/main/java/com/batoulapps/adhan/Coordinates.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/Coordinates.java
@@ -1,0 +1,11 @@
+package com.batoulapps.adhan;
+
+public class Coordinates {
+  public final double latitude;
+  public final double longitude;
+
+  public Coordinates(double latitude, double longitude) {
+    this.latitude = latitude;
+    this.longitude = longitude;
+  }
+}

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/Astronomical.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/Astronomical.java
@@ -1,0 +1,281 @@
+package com.batoulapps.adhan.internal;
+
+import com.batoulapps.adhan.Coordinates;
+
+/**
+ * Astronomical equations
+ */
+class Astronomical {
+
+  /**
+   * The geometric mean longitude of the sun in degrees.
+   * @param T the julian century
+   * @return the geometric longitude of the sun in degrees
+   */
+  static double meanSolarLongitude(double T) {
+    /* Equation from Astronomical Algorithms page 163 */
+    final double term1 = 280.4664567;
+    final double term2 = 36000.76983 * T;
+    final double term3 = 0.0003032 * Math.pow(T, 2);
+    final double L0 = term1 + term2 + term3;
+    return DoubleUtil.unwindAngle(L0);
+  }
+
+  /**
+   * The geometric mean longitude of the moon in degrees
+   * @param T the julian century
+   * @return the geometric mean longitude of the moon in degrees
+   */
+  static double meanLunarLongitude(double T) {
+    /* Equation from Astronomical Algorithms page 144 */
+    final double term1 = 218.3165;
+    final double term2 = 481267.8813 * T;
+    final double Lp = term1 + term2;
+    return DoubleUtil.unwindAngle(Lp);
+  }
+
+  /**
+   * The apparent longitude of the Sun, referred to the true equinox of the date.
+   * @param T the julian century
+   * @param L0 the mean longitude
+   * @return the true equinox of the date
+   */
+  static double apparentSolarLongitude(double T, double L0) {
+    /* Equation from Astronomical Algorithms page 164 */
+    final double longitude = L0 + solarEquationOfTheCenter(T, meanSolarAnomaly(T));
+    final double Ω = 125.04 - (1934.136 * T);
+    final double λ = longitude - 0.00569 - (0.00478 * Math.sin(Math.toRadians(Ω)));
+    return DoubleUtil.unwindAngle(λ);
+  }
+
+  /**
+   * The ascending lunar node longitude
+   * @param T the julian century
+   * @return the ascending lunar node longitude
+   */
+  static double ascendingLunarNodeLongitude(double T) {
+    /* Equation from Astronomical Algorithms page 144 */
+    final double term1 = 125.04452;
+    final double term2 = 1934.136261 * T;
+    final double term3 = 0.0020708 * Math.pow(T, 2);
+    final double term4 = Math.pow(T, 3) / 450000;
+    final double Ω = term1 - term2 + term3 + term4;
+    return DoubleUtil.unwindAngle(Ω);
+  }
+
+  /**
+   * The mean anomaly of the sun
+   * @param T the julian century
+   * @return the mean solar anomaly
+   */
+  static double meanSolarAnomaly(double T) {
+    /* Equation from Astronomical Algorithms page 163 */
+    final double term1 = 357.52911;
+    final double term2 = 35999.05029 * T;
+    final double term3 = 0.0001537 * Math.pow(T, 2);
+    final double M = term1 + term2 - term3;
+    return DoubleUtil.unwindAngle(M);
+  }
+
+  /**
+   * The Sun's equation of the center in degrees.
+   * @param T the julian century
+   * @param M the mean anomaly
+   * @return the sun's equation of the center in degrees
+   */
+  static double solarEquationOfTheCenter(double T, double M) {
+    /* Equation from Astronomical Algorithms page 164 */
+    final double Mrad = Math.toRadians(M);
+    final double term1 = (1.914602 - (0.004817 * T) - (0.000014 * Math.pow(T, 2))) * Math.sin(Mrad);
+    final double term2 = (0.019993 - (0.000101 * T)) * Math.sin(2 * Mrad);
+    final double term3 = 0.000289 * Math.sin(3 * Mrad);
+    return term1 + term2 + term3;
+  }
+
+  /**
+   * The mean obliquity of the ecliptic in degrees
+   * formula adopted by the International Astronomical Union.
+   * @param T the julian century
+   * @return the mean obliquity of the ecliptic in degrees
+   */
+  static double meanObliquityOfTheEcliptic(double T) {
+    /* Equation from Astronomical Algorithms page 147 */
+    final double term1 = 23.439291;
+    final double term2 = 0.013004167 * T;
+    final double term3 = 0.0000001639 * Math.pow(T, 2);
+    final double term4 = 0.0000005036 * Math.pow(T, 3);
+    return term1 - term2 - term3 + term4;
+  }
+
+  /**
+   * The mean obliquity of the ecliptic, corrected for calculating the
+   * apparent position of the sun, in degrees.
+   * @param T the julian century
+   * @param ε0 the mean obliquity of the ecliptic
+   * @return the corrected mean obliquity of the ecliptic in degrees
+   */
+  static double apparentObliquityOfTheEcliptic(double T, double ε0) {
+    /* Equation from Astronomical Algorithms page 165 */
+    final double O = 125.04 - (1934.136 * T);
+    return ε0 + (0.00256 * Math.cos(Math.toRadians(O)));
+  }
+
+  /**
+   * Mean sidereal time, the hour angle of the vernal equinox, in degrees.
+   * @param T the julian century
+   * @return the mean sidereal time in degrees
+   */
+  static double meanSiderealTime(double T) {
+    /* Equation from Astronomical Algorithms page 165 */
+    final double JD = (T * 36525) + 2451545.0;
+    final double term1 = 280.46061837;
+    final double term2 = 360.98564736629 * (JD - 2451545);
+    final double term3 = 0.000387933 * Math.pow(T, 2);
+    final double term4 = Math.pow(T, 3) / 38710000;
+    final double θ = term1 + term2 + term3 - term4;
+    return DoubleUtil.unwindAngle(θ);
+  }
+
+  /**
+   * Get the nutation in longitude
+   * @param T the julian century
+   * @param L0 the solar longitude
+   * @param Lp the lunar longitude
+   * @param Ω the ascending node
+   * @return the nutation in longitude
+   */
+  static double nutationInLongitude(double T, double L0, double Lp, double Ω) {
+    /* Equation from Astronomical Algorithms page 144 */
+    final double term1 = (-17.2/3600) * Math.sin(Math.toRadians(Ω));
+    final double term2 =  (1.32/3600) * Math.sin(2 * Math.toRadians(L0));
+    final double term3 =  (0.23/3600) * Math.sin(2 * Math.toRadians(Lp));
+    final double term4 =  (0.21/3600) * Math.sin(2 * Math.toRadians(Ω));
+    return term1 - term2 - term3 + term4;
+  }
+
+  /**
+   * Get the nutation in obliquity
+   * @param T the julian century
+   * @param L0 the solar longitude
+   * @param Lp the lunar longitude
+   * @param Ω the ascending node
+   * @return
+   */
+  static double nutationInObliquity(double T, double L0, double Lp, double Ω) {
+    /* Equation from Astronomical Algorithms page 144 */
+    final double term1 =  (9.2/3600) * Math.cos(Math.toRadians(Ω));
+    final double term2 = (0.57/3600) * Math.cos(2 * Math.toRadians(L0));
+    final double term3 = (0.10/3600) * Math.cos(2 * Math.toRadians(Lp));
+    final double term4 = (0.09/3600) * Math.cos(2 * Math.toRadians(Ω));
+    return term1 + term2 + term3 - term4;
+  }
+
+  /**
+   * Return the altitude of the celestial body
+   * @param φ the observer latitude
+   * @param δ the declination
+   * @param H the local hour angle
+   * @return the altitude of the celestial body
+   */
+  static double altitudeOfCelestialBody(double φ, double δ, double H) {
+    /* Equation from Astronomical Algorithms page 93 */
+    final double term1 = Math.sin(Math.toRadians(φ)) * Math.sin(Math.toRadians(δ));
+    final double term2 = Math.cos(Math.toRadians(φ)) *
+        Math.cos(Math.toRadians(δ)) * Math.cos(Math.toRadians(H));
+    return Math.toDegrees(Math.asin(term1 + term2));
+  }
+
+  /**
+   * Return the approximate transite
+   * @param L the longitude
+   * @param Θ0 the sidereal time
+   * @param α2 the right ascension
+   * @return the approximate transite
+   */
+  static double approximateTransit(double L, double Θ0, double α2) {
+    /* Equation from page Astronomical Algorithms 102 */
+    final double Lw = L * -1;
+    return DoubleUtil.normalizeWithBound((α2 + Lw - Θ0) / 360, 1);
+  }
+
+  /**
+   * The time at which the sun is at its highest point in the sky (in universal time)
+   * @param m0 approximate transit
+   * @param L the longitude
+   * @param Θ0 the sidereal time
+   * @param α2 the right ascension
+   * @param α1 the previous right ascension
+   * @param α3 the next right ascension
+   * @return the time (in universal time) when the sun is at its highest point in the sky
+   */
+  static double correctedTransit(double m0, double L, double Θ0, double α2, double α1, double α3) {
+        /* Equation from page Astronomical Algorithms 102 */
+    final double Lw = L * -1;
+    final double θ = DoubleUtil.unwindAngle(Θ0 + (360.985647 * m0));
+    final double α = interpolate(
+        /* value */ α2, /* previousValue */ α1, /* nextValue */ α3, /* factor */ m0);
+    final double H = (θ - Lw - α);
+    final double Δm = (H >= -180 && H <= 180) ? H / -360 : 0;
+    return (m0 + Δm) * 24;
+  }
+
+  /**
+   * Get the corrected hour angle
+   * @param m0 the approximate transit
+   * @param h0 the angle
+   * @param coordinates the coordinates
+   * @param afterTransit whether it's after transit
+   * @param Θ0 the sidereal time
+   * @param α2 the right ascension
+   * @param α1 the previous right ascension
+   * @param α3 the next right ascension
+   * @param δ2 the declination
+   * @param δ1 the previous declination
+   * @param δ3 the next declination
+   * @return the corrected hour angle
+   */
+  static double correctedHourAngle(double m0, double h0, Coordinates coordinates, boolean afterTransit,
+      double Θ0, double α2, double α1, double α3, double δ2, double δ1, double δ3) {
+    /* Equation from page Astronomical Algorithms 102 */
+    final double Lw = coordinates.longitude * -1;
+    final double term1 = Math.sin(Math.toRadians(h0)) -
+        (Math.sin(Math.toRadians(coordinates.latitude)) * Math.sin(Math.toRadians(δ2)));
+    final double term2 = Math.cos(Math.toRadians(coordinates.latitude)) * Math.cos(Math.toRadians(δ2));
+    final double H0 = Math.toDegrees(Math.acos(term1 / term2));
+    final double m = afterTransit ? m0 + (H0 / 360) : m0 - (H0 / 360);
+    final double θ = DoubleUtil.unwindAngle(Θ0 + (360.985647 * m));
+    final double α = interpolate(/* value */ α2, /* previousValue */ α1,
+        /* nextValue */ α3, /* factor */ m);
+    final double δ = interpolate(/* value */ δ2, /* previousValue */ δ1,
+        /* nextValue */ δ3, /* factor */ m);
+    final double H = (θ - Lw - α);
+    final double h = altitudeOfCelestialBody(/* observerLatitude */ coordinates.latitude,
+        /* declination */ δ, /* localHourAngle */ H);
+    final double term3 = h - h0;
+    final double term4 = 360 * Math.cos(Math.toRadians(δ)) *
+        Math.cos(Math.toRadians(coordinates.latitude)) * Math.sin(Math.toRadians(H));
+    final double Δm = term3 / term4;
+    return (m + Δm) * 24;
+  }
+
+  /* Interpolation of a value given equidistant
+  previous and next values and a factor
+  equal to the fraction of the interpolated
+  point's time over the time between values. */
+
+  /**
+   *
+   * @param y2 the value
+   * @param y1 the previous value
+   * @param y3 the next value
+   * @param n the factor
+   * @return the interpolated value
+   */
+  static double interpolate(double y2, double y1, double y3, double n) {
+    /* Equation from Astronomical Algorithms page 24 */
+    final double a = y2 - y1;
+    final double b = y3 - y2;
+    final double c = b - a;
+    return y2 + ((n/2) * (a + b + (n * c)));
+  }
+}

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/CalendricalHelper.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/CalendricalHelper.java
@@ -1,0 +1,59 @@
+package com.batoulapps.adhan.internal;
+
+class CalendricalHelper {
+
+  /**
+   * The Julian Day for a given Gregorian date
+   * @param year the year
+   * @param month the month
+   * @param day the day
+   * @return the julian day
+   */
+  static double julianDay(int year, int month, int day) {
+    return julianDay(year, month, day, 0.0);
+  }
+
+  /**
+   * The Julian Day for a given Gregorian date
+   * @param year the year
+   * @param month the month
+   * @param day the day
+   * @param hours hours
+   * @return the julian day
+   */
+  static double julianDay(int year, int month, int day, double hours) {
+    /* Equation from Astronomical Algorithms page 60 */
+
+    // NOTE: Integer conversion is done intentionally for the purpose of decimal truncation
+
+    int Y = month > 2 ? year : year - 1;
+    int M = month > 2 ? month : month + 12;
+    double D = day + (hours / 24);
+
+    int A = Y/100;
+    int B = 2 - A + (A/4);
+
+    int i0 = (int) (365.25 * (Y + 4716));
+    int i1 = (int) (30.6001 * (M + 1));
+    return i0 + i1 + D + B - 1524.5;
+  }
+
+  /* Julian century from the epoch. */
+  static double julianCentury(double JD) {
+    /* Equation from Astronomical Algorithms page 163 */
+    return (JD - 2451545.0) / 36525;
+  }
+
+  /* Whether or not a year is a leap year (has 366 days). */
+  static boolean isLeapYear(int year) {
+    if (year % 4 != 0) {
+      return false;
+    }
+
+    if (year % 100 == 0 && year % 400 != 0) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/DoubleUtil.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/DoubleUtil.java
@@ -1,0 +1,12 @@
+package com.batoulapps.adhan.internal;
+
+class DoubleUtil {
+
+  static double normalizeWithBound(double value, double max) {
+    return value - (max * (Math.floor(value / max)));
+  }
+
+  static double unwindAngle(double value) {
+    return normalizeWithBound(value, 360);
+  }
+}

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/SolarCoordinates.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/SolarCoordinates.java
@@ -1,0 +1,53 @@
+package com.batoulapps.adhan.internal;
+
+class SolarCoordinates {
+
+  /**
+   * The declination of the sun, the angle between
+   * the rays of the Sun and the plane of the Earth's
+   * equator, in degrees.
+   */
+  final double declination;
+
+  /**
+   *  Right ascension of the Sun, the angular distance on the
+   * celestial equator from the vernal equinox to the hour circle,
+   * in degrees.
+   */
+  final double rightAscension;
+
+  /**
+   *  Apparent sidereal time, the hour angle of the vernal
+   * equinox, in degrees.
+   */
+  final double apparentSiderealTime;
+
+  SolarCoordinates(double julianDay) {
+    double T = CalendricalHelper.julianCentury(julianDay);
+    double L0 = Astronomical.meanSolarLongitude(/* julianCentury */ T);
+    double Lp = Astronomical.meanLunarLongitude(/* julianCentury */ T);
+    double Ω = Astronomical.ascendingLunarNodeLongitude(/* julianCentury */ T);
+    double λ = Math.toRadians(
+        Astronomical.apparentSolarLongitude(/* julianCentury*/ T, /* meanLongitude */ L0));
+
+    double θ0 = Astronomical.meanSiderealTime(/* julianCentury */ T);
+    double ΔΨ = Astronomical.nutationInLongitude(/* julianCentury */ T, /* solarLongitude */ L0,
+        /* lunarLongitude */ Lp, /* ascendingNode */ Ω);
+    double Δε = Astronomical.nutationInObliquity(/* julianCentury */ T, /* solarLongitude */ L0,
+        /* lunarLongitude */ Lp, /* ascendingNode */ Ω);
+
+    double ε0 = Astronomical.meanObliquityOfTheEcliptic(/* julianCentury */ T);
+    double εapp = Math.toRadians(Astronomical.apparentObliquityOfTheEcliptic(
+        /* julianCentury */ T, /* meanObliquityOfTheEcliptic */ ε0));
+
+        /* Equation from Astronomical Algorithms page 165 */
+    this.declination = Math.toDegrees(Math.asin(Math.sin(εapp) * Math.sin(λ)));
+
+        /* Equation from Astronomical Algorithms page 165 */
+    this.rightAscension = DoubleUtil.unwindAngle(
+        Math.toDegrees(Math.atan2(Math.cos(εapp) * Math.sin(λ), Math.cos(λ))));
+
+        /* Equation from Astronomical Algorithms page 88 */
+    this.apparentSiderealTime = θ0 + (((ΔΨ * 3600) * Math.cos(Math.toRadians(ε0 + Δε))) / 3600);
+  }
+}

--- a/java/adhan/src/test/java/com/batoulapps/adhan/internal/AstronomicalTest.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/internal/AstronomicalTest.java
@@ -1,0 +1,227 @@
+package com.batoulapps.adhan.internal;
+
+import com.batoulapps.adhan.Coordinates;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class AstronomicalTest {
+
+  @Test
+  public void testSolarCoordinates() {
+
+    // values from Astronomical Algorithms page 165
+
+    double jd = CalendricalHelper.julianDay(/* year */ 1992, /* month */ 10, /* day */ 13);
+    SolarCoordinates solar = new SolarCoordinates(/* julianDay */ jd);
+
+    double T = CalendricalHelper.julianCentury(/* julianDay */ jd);
+    double L0 = Astronomical.meanSolarLongitude(/* julianCentury */ T);
+    double ε0 = Astronomical.meanObliquityOfTheEcliptic(/* julianCentury */ T);
+    final double εapp = Astronomical.apparentObliquityOfTheEcliptic(
+        /* julianCentury */ T, /* meanObliquityOfTheEcliptic */ ε0);
+    final double M = Astronomical.meanSolarAnomaly(/* julianCentury */ T);
+    final double C = Astronomical.solarEquationOfTheCenter(
+        /* julianCentury */ T, /* meanAnomaly */ M);
+    final double λ = Astronomical.apparentSolarLongitude(
+        /* julianCentury */ T, /* meanLongitude */ L0);
+    final double δ = solar.declination;
+    final double α = solar.rightAscension;
+
+    assertThat(T).isWithin(0.00000000001).of(-0.072183436);
+
+    assertThat(L0).isWithin(0.00001).of(201.80720);
+
+    assertThat(ε0).isWithin(0.00001).of(23.44023);
+
+    assertThat(εapp).isWithin(0.00001).of(23.43999);
+
+    assertThat(M).isWithin(0.00001).of(278.99397);
+
+    assertThat(C).isWithin(0.00001).of(-1.89732);
+
+    // lower accuracy than desired
+    assertThat(λ).isWithin(0.00002).of(199.90895);
+
+    assertThat(δ).isWithin(0.00001).of(-7.78507);
+
+    assertThat(α).isWithin(0.00001).of(198.38083);
+
+    // values from Astronomical Algorithms page 88
+
+    jd = CalendricalHelper.julianDay(/* year */ 1987, /* month */ 4, /* day */ 10);
+    solar = new SolarCoordinates(/* julianDay */ jd);
+    T = CalendricalHelper.julianCentury(/* julianDay */ jd);
+
+    final double θ0 = Astronomical.meanSiderealTime(/* julianCentury */ T);
+    final double θapp = solar.apparentSiderealTime;
+    final double Ω = Astronomical.ascendingLunarNodeLongitude(/* julianCentury */ T);
+    ε0 = Astronomical.meanObliquityOfTheEcliptic(/* julianCentury */ T);
+    L0 = Astronomical.meanSolarLongitude(/* julianCentury */ T);
+    final double Lp = Astronomical.meanLunarLongitude(/* julianCentury */ T);
+    final double ΔΨ = Astronomical.nutationInLongitude(/* julianCentury */ T,
+        /* solarLongitude */ L0, /* lunarLongitude */ Lp, /* ascendingNode */ Ω);
+    final double Δε = Astronomical.nutationInObliquity(/* julianCentury */ T,
+        /* solarLongitude */ L0, /* lunarLongitude */ Lp, /* ascendingNode */ Ω);
+    final double ε = ε0 + Δε;
+
+    assertThat(θ0).isWithin(0.000001).of(197.693195);
+
+    assertThat(θapp).isWithin(0.0001).of(197.6922295833);
+
+    // values from Astronomical Algorithms page 148
+
+    assertThat(Ω).isWithin(0.0001).of(11.2531);
+
+    assertThat(ΔΨ).isWithin(0.0001).of(-0.0010522);
+
+    assertThat(Δε).isWithin(0.00001).of(0.0026230556);
+
+    assertThat(ε0).isWithin(0.000001).of(23.4409463889);
+
+    assertThat(ε).isWithin(0.00001).of(23.4435694444);
+  }
+
+  @Test
+  public void testAltitudeOfCelestialBody() {
+    final double φ = 38 + (55 / 60.0) + (17.0 / 3600);
+    final double δ = -6 - (43 / 60.0) - (11.61 / 3600);
+    final double H = 64.352133;
+    final double h = Astronomical.altitudeOfCelestialBody(
+        /* observerLatitude */ φ, /* declination */ δ, /* localHourAngle */ H);
+    assertThat(h).isWithin(0.0001).of(15.1249);
+  }
+
+  @Test
+  public void testTransitAndHourAngle() {
+    // values from Astronomical Algorithms page 103
+    final double longitude = -71.0833;
+    final double Θ = 177.74208;
+    final double α1 = 40.68021;
+    final double α2 = 41.73129;
+    final double α3 = 42.78204;
+    final double m0 = Astronomical.approximateTransit(longitude,
+        /* siderealTime */ Θ, /* rightAscension */ α2);
+
+    assertThat(m0).isWithin(0.00001).of(0.81965);
+
+    final double transit = Astronomical.correctedTransit(
+        /* approximateTransit */ m0, longitude, /* siderealTime */ Θ,
+        /* rightAscension */ α2, /* previousRightAscension */ α1,
+        /* nextRightAscension */ α3) / 24;
+
+    assertThat(transit).isWithin(0.00001).of(0.81980);
+
+    final double δ1 = 18.04761;
+    final double δ2 = 18.44092;
+    final double δ3 = 18.82742;
+
+    final double rise = Astronomical.correctedHourAngle(/* approximateTransit */ m0,
+        /* angle */ -0.5667, new Coordinates(/* latitude */ 42.3333, longitude),
+        /* afterTransit */ false, /* siderealTime */ Θ,
+        /* rightAscension */ α2, /* previousRightAscension */ α1,
+        /* nextRightAscension */ α3, /* declination */ δ2,
+        /* previousDeclination */ δ1, /* nextDeclination */ δ3) / 24;
+    assertThat(rise).isWithin(0.00001).of(0.51766);
+  }
+
+  @Test
+  public void testSolarTime() {
+    // TODO
+  }
+
+  @Test
+  public void testCalendricalDate() {
+    // TODO
+  }
+
+  @Test
+  public void testInterpolation() {
+    // values from Astronomical Algorithms page 25
+    final double interpolatedValue = Astronomical.interpolate(/* value */ 0.877366,
+        /* previousValue */ 0.884226, /* nextValue */ 0.870531, /* factor */ 4.35/24);
+    assertThat(interpolatedValue).isWithin(0.000001).of(0.876125);
+  }
+
+  @Test
+  public void testJulianDay() {
+    /*
+    Comparison values generated from http://aa.usno.navy.mil/data/docs/JulianDate.php
+    */
+
+    assertThat(CalendricalHelper.julianDay(/* year */ 2010, /* month */ 1, /* day */ 2))
+        .isWithin(0.00001).of(2455198.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2011, /* month */ 2, /* day */ 4))
+        .isWithin(0.00001).of(2455596.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2012, /* month */ 3, /* day */ 6))
+        .isWithin(0.00001).of(2455992.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2013, /* month */ 4, /* day */ 8))
+        .isWithin(0.00001).of(2456390.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2014, /* month */ 5, /* day */ 10))
+        .isWithin(0.00001).of(2456787.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2015, /* month */ 6, /* day */ 12))
+        .isWithin(0.00001).of(2457185.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2016, /* month */ 7, /* day */ 14))
+        .isWithin(0.00001).of(2457583.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2017, /* month */ 8, /* day */ 16))
+        .isWithin(0.00001).of(2457981.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2018, /* month */ 9, /* day */ 18))
+        .isWithin(0.00001).of(2458379.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2019, /* month */ 10, /* day */ 20))
+        .isWithin(0.00001).of(2458776.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2020, /* month */ 11, /* day */ 22))
+        .isWithin(0.00001).of(2459175.500000);
+    assertThat(CalendricalHelper.julianDay(/* year */ 2021, /* month */ 12, /* day */ 24))
+        .isWithin(0.00001).of(2459572.500000);
+
+    final double jdVal = 2457215.67708333;
+    assertThat(
+        CalendricalHelper.julianDay(/* year */ 2015, /* month */ 7, /* day */ 12, /* hours */ 4.25))
+        .isWithin(0.000001).of(jdVal);
+
+    /* TODO fix this once we decide on what to use for Calendar (joda time or java 6 apis)
+    let components = NSDateComponents()
+    components.year = 2015
+    components.month = 7
+    components.day = 12
+    components.hour = 4
+    components.minute = 15
+    XCTAssertEqualWithAccuracy(components.julianDate(), jdVal, accuracy: 0.000001)
+    */
+
+    assertThat(CalendricalHelper
+        .julianDay(/* year */ 2015, /* month */ 7, /* day */ 12, /* hours */ 8.0))
+        .isWithin(0.000001)
+        .of(2457215.833333);
+    assertThat(CalendricalHelper
+        .julianDay(/* year */ 1992, /* month */ 10, /* day */ 13, /* hours */ 0.0))
+        .isWithin(0.000001)
+        .of(2448908.5);
+  }
+
+  @Test
+  public void testJulianHours() {
+    final double j1 = CalendricalHelper.julianDay(/* year */ 2010, /* month */ 1, /* day */ 3);
+    final double j2 = CalendricalHelper.julianDay(/* year */ 2010,
+        /* month */ 1, /* day */ 1, /* hours */ 48);
+    assertThat(j1).isWithin(0.0000001).of(j2);
+  }
+
+  @Test
+  public void testLeapYear() {
+    assertThat(CalendricalHelper.isLeapYear(2015)).isFalse();
+    assertThat(CalendricalHelper.isLeapYear(2016)).isTrue();
+    assertThat(CalendricalHelper.isLeapYear(1600)).isTrue();
+    assertThat(CalendricalHelper.isLeapYear(2000)).isTrue();
+    assertThat(CalendricalHelper.isLeapYear(2400)).isTrue();
+    assertThat(CalendricalHelper.isLeapYear(1700)).isFalse();
+    assertThat(CalendricalHelper.isLeapYear(1800)).isFalse();
+    assertThat(CalendricalHelper.isLeapYear(1900)).isFalse();
+    assertThat(CalendricalHelper.isLeapYear(2100)).isFalse();
+    assertThat(CalendricalHelper.isLeapYear(2200)).isFalse();
+    assertThat(CalendricalHelper.isLeapYear(2300)).isFalse();
+    assertThat(CalendricalHelper.isLeapYear(2500)).isFalse();
+    assertThat(CalendricalHelper.isLeapYear(2600)).isFalse();
+  }
+}


### PR DESCRIPTION
This ports most of the astronomical functions and their corresponding tests to Java. This does not yet port the tests that require a calendar representation (ex SolarTime related tests, etc).

The variable names were mostly kept from the Swift ones, despite their breaking normal Java variable naming conventions. However, this was done to maintain readability and to be easily able to map back to the formulas from the book if needed.
