### PR TITLE
PrayerTimes should return GMT times

### DIFF
--- a/java/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
@@ -15,12 +15,12 @@ import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.temporal.ChronoUnit;
 
 public class PrayerTimes {
-  public final LocalDateTime fajr;
-  public final LocalDateTime sunrise;
-  public final LocalDateTime dhuhr;
-  public final LocalDateTime asr;
-  public final LocalDateTime maghrib;
-  public final LocalDateTime isha;
+  public final ZonedDateTime fajr;
+  public final ZonedDateTime sunrise;
+  public final ZonedDateTime dhuhr;
+  public final ZonedDateTime asr;
+  public final ZonedDateTime maghrib;
+  public final ZonedDateTime isha;
 
   public PrayerTimes(Coordinates coordinates, LocalDate date, CalculationParameters parameters) {
     ZonedDateTime tempFajr = null;
@@ -154,19 +154,17 @@ public class PrayerTimes {
     } else {
       // Assign final times to public struct members with all offsets
       this.fajr = CalendricalHelper.roundedMinute(
-          tempFajr.plus(parameters.adjustments.fajr, ChronoUnit.MINUTES).toLocalDateTime());
+          tempFajr.plus(parameters.adjustments.fajr, ChronoUnit.MINUTES));
       this.sunrise = CalendricalHelper.roundedMinute(
-          tempSunrise.plus(parameters.adjustments.sunrise, ChronoUnit.MINUTES).toLocalDateTime());
+          tempSunrise.plus(parameters.adjustments.sunrise, ChronoUnit.MINUTES));
       this.dhuhr = CalendricalHelper.roundedMinute(
-          tempDhuhr.plus(parameters.adjustments.dhuhr, ChronoUnit.MINUTES)
-              .plus(dhuhrOffset).toLocalDateTime());
+          tempDhuhr.plus(parameters.adjustments.dhuhr, ChronoUnit.MINUTES).plus(dhuhrOffset));
       this.asr = CalendricalHelper.roundedMinute(
-          tempAsr.plus(parameters.adjustments.asr, ChronoUnit.MINUTES).toLocalDateTime());
+          tempAsr.plus(parameters.adjustments.asr, ChronoUnit.MINUTES));
       this.maghrib = CalendricalHelper.roundedMinute(
-          tempMaghrib.plus(parameters.adjustments.maghrib, ChronoUnit.MINUTES)
-              .plus(maghribOffset).toLocalDateTime());
+          tempMaghrib.plus(parameters.adjustments.maghrib, ChronoUnit.MINUTES).plus(maghribOffset));
       this.isha = CalendricalHelper.roundedMinute(
-          tempIsha.plus(parameters.adjustments.isha, ChronoUnit.MINUTES).toLocalDateTime());
+          tempIsha.plus(parameters.adjustments.isha, ChronoUnit.MINUTES));
     }
   }
 

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/CalendricalHelper.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/CalendricalHelper.java
@@ -3,6 +3,7 @@ package com.batoulapps.adhan.internal;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.Year;
+import org.threeten.bp.ZonedDateTime;
 
 public class CalendricalHelper {
 
@@ -82,12 +83,12 @@ public class CalendricalHelper {
   }
 
   /**
-   * Local date and time with a rounded minute
+   * Zoned date and time with a rounded minute
    * This returns a date with the seconds rounded and added to the minute
    * @param when the date and time
    * @return the date and time with 0 seconds and minutes including rounded seconds
    */
-  public static LocalDateTime roundedMinute(LocalDateTime when) {
+  public static ZonedDateTime roundedMinute(ZonedDateTime when) {
     final double minute = when.getMinute();
     final double second = when.getSecond();
     return when.withMinute((int) (minute + Math.round(second / 60))).withSecond(0);

--- a/java/adhan/src/test/java/com/batoulapps/adhan/PrayerTimesTest.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/PrayerTimesTest.java
@@ -3,7 +3,6 @@ package com.batoulapps.adhan;
 import org.junit.Test;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -49,7 +48,6 @@ public class PrayerTimesTest {
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm a")
         .withZone(ZoneId.of("America/New_York"));
-    ZoneId utc = ZoneId.of("UTC");
 
     assertThat(prayerTimes.fajr).isNotNull();
     assertThat(prayerTimes.sunrise).isNotNull();
@@ -58,12 +56,12 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(ZonedDateTime.of(prayerTimes.fajr, utc).format(formatter)).isEqualTo("04:42 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.sunrise, utc).format(formatter)).isEqualTo("06:08 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.dhuhr, utc).format(formatter)).isEqualTo("01:21 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.asr, utc).format(formatter)).isEqualTo("06:22 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.maghrib, utc).format(formatter)).isEqualTo("08:32 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.isha, utc).format(formatter)).isEqualTo("09:57 PM");
+    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("04:42 AM");
+    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("06:08 AM");
+    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("01:21 PM");
+    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("06:22 PM");
+    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("08:32 PM");
+    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("09:57 PM");
   }
 
   @Test
@@ -73,8 +71,6 @@ public class PrayerTimesTest {
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm a")
         .withZone(ZoneId.of("America/New_York"));
-    ZoneId utc = ZoneId.of("UTC");
-
     CalculationParameters parameters = CalculationMethod.MUSLIM_WORLD_LEAGUE.getParameters();
 
     PrayerTimes prayerTimes = new PrayerTimes(coordinates, date, parameters);
@@ -85,12 +81,12 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(ZonedDateTime.of(prayerTimes.fajr, utc).format(formatter)).isEqualTo("05:35 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.sunrise, utc).format(formatter)).isEqualTo("07:06 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.dhuhr, utc).format(formatter)).isEqualTo("12:05 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.asr, utc).format(formatter)).isEqualTo("02:42 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.maghrib, utc).format(formatter)).isEqualTo("05:01 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.isha, utc).format(formatter)).isEqualTo("06:26 PM");
+    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("05:35 AM");
+    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("07:06 AM");
+    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("12:05 PM");
+    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("02:42 PM");
+    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("05:01 PM");
+    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("06:26 PM");
 
     parameters.adjustments.fajr = 10;
     parameters.adjustments.sunrise = 10;
@@ -107,12 +103,12 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(ZonedDateTime.of(prayerTimes.fajr, utc).format(formatter)).isEqualTo("05:45 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.sunrise, utc).format(formatter)).isEqualTo("07:16 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.dhuhr, utc).format(formatter)).isEqualTo("12:15 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.asr, utc).format(formatter)).isEqualTo("02:52 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.maghrib, utc).format(formatter)).isEqualTo("05:11 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.isha, utc).format(formatter)).isEqualTo("06:36 PM");
+    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("05:45 AM");
+    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("07:16 AM");
+    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("12:15 PM");
+    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("02:52 PM");
+    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("05:11 PM");
+    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("06:36 PM");
 
     parameters.adjustments = new PrayerAdjustments();
     prayerTimes = new PrayerTimes(coordinates, date, parameters);
@@ -123,24 +119,23 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(ZonedDateTime.of(prayerTimes.fajr, utc).format(formatter)).isEqualTo("05:35 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.sunrise, utc).format(formatter)).isEqualTo("07:06 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.dhuhr, utc).format(formatter)).isEqualTo("12:05 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.asr, utc).format(formatter)).isEqualTo("02:42 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.maghrib, utc).format(formatter)).isEqualTo("05:01 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.isha, utc).format(formatter)).isEqualTo("06:26 PM");
+    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("05:35 AM");
+    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("07:06 AM");
+    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("12:05 PM");
+    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("02:42 PM");
+    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("05:01 PM");
+    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("06:26 PM");
   }
 
   @Test
   public void testMoonsightingMethod() {
-    LocalDate date = LocalDate.of(2106, 1, 31);
+    LocalDate date = LocalDate.of(2016, 1, 31);
     Coordinates coordinates = new Coordinates(35.7750, -78.6336);
     PrayerTimes prayerTimes = new PrayerTimes(
         coordinates, date, CalculationMethod.MOON_SIGHTING_COMMITTEE.getParameters());
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm a")
         .withZone(ZoneId.of("America/New_York"));
-    ZoneId utc = ZoneId.of("UTC");
 
     assertThat(prayerTimes.fajr).isNotNull();
     assertThat(prayerTimes.sunrise).isNotNull();
@@ -149,11 +144,11 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(ZonedDateTime.of(prayerTimes.fajr, utc).format(formatter)).isEqualTo("05:48 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.sunrise, utc).format(formatter)).isEqualTo("07:16 AM");
-    assertThat(ZonedDateTime.of(prayerTimes.dhuhr, utc).format(formatter)).isEqualTo("12:33 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.asr, utc).format(formatter)).isEqualTo("03:20 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.maghrib, utc).format(formatter)).isEqualTo("05:43 PM");
-    assertThat(ZonedDateTime.of(prayerTimes.isha, utc).format(formatter)).isEqualTo("07:05 PM");
+    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("05:48 AM");
+    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("07:16 AM");
+    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("12:33 PM");
+    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("03:20 PM");
+    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("05:43 PM");
+    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("07:05 PM");
   }
 }

--- a/java/adhan/src/test/java/com/batoulapps/adhan/internal/MathTest.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/internal/MathTest.java
@@ -2,6 +2,8 @@ package com.batoulapps.adhan.internal;
 
 import org.junit.Test;
 import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -67,13 +69,15 @@ public class MathTest {
 
   @Test
   public void testMinuteRounding() {
-    final LocalDateTime comps1 = LocalDateTime.of(2015, 1, 1, 10, 2, 29);
-    final LocalDateTime rounded1 = CalendricalHelper.roundedMinute(comps1);
+    final ZonedDateTime comps1 =
+        ZonedDateTime.of(LocalDateTime.of(2015, 1, 1, 10, 2, 29), ZoneId.of("GMT"));
+    final ZonedDateTime rounded1 = CalendricalHelper.roundedMinute(comps1);
     assertThat(rounded1.getMinute()).isEqualTo(2);
     assertThat(rounded1.getSecond()).isEqualTo(0);
 
-    final LocalDateTime comps2 = LocalDateTime.of(2015, 1, 1, 10, 2, 31);
-    final LocalDateTime rounded2 = CalendricalHelper.roundedMinute(comps2);
+    final ZonedDateTime comps2 =
+        ZonedDateTime.of(LocalDateTime.of(2015, 1, 1, 10, 2, 31), ZoneId.of("GMT"));
+    final ZonedDateTime rounded2 = CalendricalHelper.roundedMinute(comps2);
     assertThat(rounded2.getMinute()).isEqualTo(3);
     assertThat(rounded2.getSecond()).isEqualTo(0);
   }


### PR DESCRIPTION
Previously, PrayerTimes was converting the ZonedDateTimes to plain
vanilla LocalDateTimes - this was confusing. This behavior now is closer
to what is done in Swift, and makes it easier for the developer to
convert the times to whatever timezone makes sense.
