### PR TITLE
Use java6 time apis instead of JSR310 backport

### DIFF
--- a/java/adhan/pom.xml
+++ b/java/adhan/pom.xml
@@ -12,11 +12,6 @@
     <artifactId>adhan</artifactId>
 
     <dependencies>
-        <dependency>
-            <groupId>org.threeten</groupId>
-            <artifactId>threetenbp</artifactId>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/java/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
@@ -1,149 +1,145 @@
 package com.batoulapps.adhan;
 
 import com.batoulapps.adhan.internal.CalendricalHelper;
+import com.batoulapps.adhan.internal.DateComponents;
 import com.batoulapps.adhan.internal.DoubleUtil;
 import com.batoulapps.adhan.internal.SolarTime;
 import com.batoulapps.adhan.internal.TimeComponents;
 
-import org.threeten.bp.Duration;
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.LocalTime;
-import org.threeten.bp.Year;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.temporal.ChronoUnit;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 public class PrayerTimes {
-  public final ZonedDateTime fajr;
-  public final ZonedDateTime sunrise;
-  public final ZonedDateTime dhuhr;
-  public final ZonedDateTime asr;
-  public final ZonedDateTime maghrib;
-  public final ZonedDateTime isha;
+  public final Date fajr;
+  public final Date sunrise;
+  public final Date dhuhr;
+  public final Date asr;
+  public final Date maghrib;
+  public final Date isha;
 
-  public PrayerTimes(Coordinates coordinates, LocalDate date, CalculationParameters parameters) {
-    ZonedDateTime tempFajr = null;
-    ZonedDateTime tempSunrise = null;
-    ZonedDateTime tempDhuhr = null;
-    ZonedDateTime tempAsr = null;
-    ZonedDateTime tempMaghrib = null;
-    ZonedDateTime tempIsha = null;
+  public PrayerTimes(Coordinates coordinates, DateComponents date, CalculationParameters params) {
+    this(coordinates, CalendricalHelper.resolveTime(date), params);
+  }
 
-    ZoneId timeZone = ZoneId.of("UTC");
-    ZonedDateTime prayerDate = ZonedDateTime.of(date, LocalTime.MIN, timeZone);
+  private PrayerTimes(Coordinates coordinates, Date date, CalculationParameters parameters) {
+    Date tempFajr = null;
+    Date tempSunrise = null;
+    Date tempDhuhr = null;
+    Date tempAsr = null;
+    Date tempMaghrib = null;
+    Date tempIsha = null;
+
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(date);
+
+    final int year = calendar.get(Calendar.YEAR);
+    final int dayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
 
     SolarTime solarTime = new SolarTime(date, coordinates);
 
     TimeComponents timeComponents = DoubleUtil.timeComponents(solarTime.transit);
-    LocalDateTime transit = timeComponents == null ? null : timeComponents.dateComponents(date);
+    Date transit = timeComponents == null ? null : timeComponents.dateComponents(date);
 
     timeComponents = DoubleUtil.timeComponents(solarTime.sunrise);
-    LocalDateTime sunriseComponents = timeComponents == null ?
-        null : timeComponents.dateComponents(date);
+    Date sunriseComponents = timeComponents == null ? null : timeComponents.dateComponents(date);
 
     timeComponents = DoubleUtil.timeComponents(solarTime.sunset);
-    LocalDateTime sunsetComponents = timeComponents == null ?
-        null : timeComponents.dateComponents(date);
+    Date sunsetComponents = timeComponents == null ? null : timeComponents.dateComponents(date);
 
     boolean error = transit == null || sunriseComponents == null || sunsetComponents == null;
     if (!error) {
-      ZonedDateTime sunriseDate = ZonedDateTime.of(sunriseComponents, timeZone);
-      ZonedDateTime sunsetDate = ZonedDateTime.of(sunsetComponents, timeZone);
-
-      tempDhuhr = ZonedDateTime.of(transit, timeZone);
-      tempSunrise = sunriseDate;
-      tempMaghrib = sunsetDate;
+      tempDhuhr = transit;
+      tempSunrise = sunriseComponents;
+      tempMaghrib = sunsetComponents;
 
       timeComponents = DoubleUtil.timeComponents(
           solarTime.afternoon(parameters.madhab.getShadowLength()));
       if (timeComponents != null) {
-        LocalDateTime when = timeComponents.dateComponents(date);
-        tempAsr = ZonedDateTime.of(when, timeZone);
+        tempAsr = timeComponents.dateComponents(date);
       }
 
       timeComponents = DoubleUtil.timeComponents(solarTime.hourAngle(-parameters.fajrAngle, false));
       if (timeComponents != null) {
-        LocalDateTime when = timeComponents.dateComponents(date);
-        tempFajr = ZonedDateTime.of(when, timeZone);
+        tempFajr = timeComponents.dateComponents(date);
       }
 
       // get night length
-      ZonedDateTime tomorrowSunrise = sunriseDate.plus(1, ChronoUnit.DAYS);
-      Duration night = Duration.between(sunsetDate, tomorrowSunrise);
+      Date tomorrowSunrise = CalendricalHelper.add(sunriseComponents, 1, Calendar.DAY_OF_YEAR);
+      long night = tomorrowSunrise.getTime() - sunsetComponents.getTime();
 
-      final ZonedDateTime safeFajr;
+      final Date safeFajr;
       if (parameters.method == CalculationMethod.MOON_SIGHTING_COMMITTEE) {
         if (coordinates.latitude < 55) {
-          int dayOfYear = prayerDate.getDayOfYear();
           safeFajr = seasonAdjustedFajr(
-              coordinates.latitude, dayOfYear, date.getYear(), sunriseDate);
+              coordinates.latitude, dayOfYear, year, sunriseComponents);
         } else {
-          Duration nightFraction = night.dividedBy(7);
-          safeFajr = sunriseDate.minus(nightFraction);
+          safeFajr = CalendricalHelper.add(
+              sunriseComponents, -1 * (int) (night / 7000), Calendar.SECOND);
         }
       } else {
         double portion = parameters.nightPortions().first;
-        long nightFraction = (long) (portion * night.getSeconds());
-        safeFajr = sunriseDate.minus(nightFraction, ChronoUnit.SECONDS);
+        long nightFraction = (long) (portion * night / 1000);
+        safeFajr = CalendricalHelper.add(
+            sunriseComponents, -1 * (int) nightFraction, Calendar.SECOND);
       }
 
-      if (tempFajr == null || (safeFajr != null && tempFajr.isBefore(safeFajr))) {
+      if (tempFajr == null || tempFajr.before(safeFajr)) {
         tempFajr = safeFajr;
       }
 
       // Isha calculation with check against safe value
       if (parameters.ishaInterval > 0) {
-        tempIsha = tempMaghrib.plus(parameters.ishaInterval * 60, ChronoUnit.SECONDS);
+        tempIsha = CalendricalHelper.add(
+            tempMaghrib, parameters.ishaInterval * 60, Calendar.SECOND);
       } else {
         timeComponents = DoubleUtil.timeComponents(
             solarTime.hourAngle(-parameters.ishaAngle, true));
         if (timeComponents != null) {
-          LocalDateTime when = timeComponents.dateComponents(date);
-          tempIsha = ZonedDateTime.of(when, timeZone);
+          tempIsha = timeComponents.dateComponents(date);
         }
 
-        final ZonedDateTime safeIsha;
+        final Date safeIsha;
         if (parameters.method == CalculationMethod.MOON_SIGHTING_COMMITTEE) {
           if (coordinates.latitude < 55) {
-            int dayOfYear = prayerDate.getDayOfYear();
             safeIsha = PrayerTimes.seasonAdjustedIsha(
-                coordinates.latitude, dayOfYear, date.getYear(), sunsetDate);
+                coordinates.latitude, dayOfYear, year, sunsetComponents);
           } else {
-            Duration nightFraction = night.dividedBy(7);
-            safeIsha = sunsetDate.plus(nightFraction);
+            safeIsha = CalendricalHelper.add(sunsetComponents,
+                (int) (night / 7000), Calendar.SECOND);
           }
         } else {
           double portion = parameters.nightPortions().second;
-          long nightFraction = (long) (portion * night.getSeconds());
-          safeIsha = sunsetDate.plus(nightFraction, ChronoUnit.SECONDS);
+          long nightFraction = (long) (portion * night / 1000);
+          safeIsha = CalendricalHelper.add(sunsetComponents, (int) nightFraction, Calendar.SECOND);
         }
 
-        if (tempIsha == null || (safeIsha != null && tempIsha.isAfter(safeIsha))) {
+        if (tempIsha == null || (tempIsha.after(safeIsha))) {
           tempIsha = safeIsha;
         }
       }
     }
 
     // method based offsets
-    final Duration dhuhrOffset;
+    final int dhuhrOffsetInMinutes;
     if (parameters.method == CalculationMethod.MOON_SIGHTING_COMMITTEE) {
       // Moonsighting Committee requires 5 minutes for the sun to pass
       // the zenith and dhuhr to enter
-      dhuhrOffset = Duration.ofMinutes(5);
+      dhuhrOffsetInMinutes = 5;
     } else {
-      dhuhrOffset = Duration.ofMinutes(1);
+      dhuhrOffsetInMinutes = 1;
     }
 
-    final Duration maghribOffset;
+    final int maghribOffsetInMinutes;
     if (parameters.method == CalculationMethod.MOON_SIGHTING_COMMITTEE) {
       // Moonsighting Committee adds 3 minutes to sunset time to account for light refraction
-      maghribOffset = Duration.ofMinutes(3);
+      maghribOffsetInMinutes = 3;
     } else {
-      maghribOffset = Duration.ZERO;
+      maghribOffsetInMinutes = 0;
     }
 
-    if (error || tempFajr == null || tempAsr == null || tempIsha == null) {
+    if (error || tempAsr == null) {
       // if we don't have all prayer times then initialization failed
       this.fajr = null;
       this.sunrise = null;
@@ -153,23 +149,22 @@ public class PrayerTimes {
       this.isha = null;
     } else {
       // Assign final times to public struct members with all offsets
-      this.fajr = CalendricalHelper.roundedMinute(
-          tempFajr.plus(parameters.adjustments.fajr, ChronoUnit.MINUTES));
+      this.fajr = CalendricalHelper.roundedMinute(CalendricalHelper.add(
+          tempFajr, parameters.adjustments.fajr, Calendar.MINUTE));
       this.sunrise = CalendricalHelper.roundedMinute(
-          tempSunrise.plus(parameters.adjustments.sunrise, ChronoUnit.MINUTES));
-      this.dhuhr = CalendricalHelper.roundedMinute(
-          tempDhuhr.plus(parameters.adjustments.dhuhr, ChronoUnit.MINUTES).plus(dhuhrOffset));
-      this.asr = CalendricalHelper.roundedMinute(
-          tempAsr.plus(parameters.adjustments.asr, ChronoUnit.MINUTES));
-      this.maghrib = CalendricalHelper.roundedMinute(
-          tempMaghrib.plus(parameters.adjustments.maghrib, ChronoUnit.MINUTES).plus(maghribOffset));
-      this.isha = CalendricalHelper.roundedMinute(
-          tempIsha.plus(parameters.adjustments.isha, ChronoUnit.MINUTES));
+          CalendricalHelper.add(tempSunrise, parameters.adjustments.sunrise, Calendar.MINUTE));
+      this.dhuhr = CalendricalHelper.roundedMinute(CalendricalHelper.add(
+          tempDhuhr, parameters.adjustments.dhuhr + dhuhrOffsetInMinutes, Calendar.MINUTE));
+      this.asr = CalendricalHelper.roundedMinute(CalendricalHelper.add(
+          tempAsr, parameters.adjustments.asr, Calendar.MINUTE));
+      this.maghrib = CalendricalHelper.roundedMinute(CalendricalHelper.add(
+          tempMaghrib, parameters.adjustments.maghrib + maghribOffsetInMinutes, Calendar.MINUTE));
+      this.isha = CalendricalHelper.roundedMinute(CalendricalHelper.add(
+          tempIsha, parameters.adjustments.isha, Calendar.MINUTE));
     }
   }
 
-  private static ZonedDateTime seasonAdjustedFajr(
-      double latitude, int day, int year, ZonedDateTime sunrise) {
+  private static Date seasonAdjustedFajr(double latitude, int day, int year, Date sunrise) {
     final double a = 75 + ((28.65 / 55.0) * Math.abs(latitude));
     final double b = 75 + ((19.44 / 55.0) * Math.abs(latitude));
     final double c = 75 + ((32.74 / 55.0) * Math.abs(latitude));
@@ -191,11 +186,10 @@ public class PrayerTimes {
       adjustment = b + ( a - b ) / 91.0 * ( dyy - 275 );
     }
 
-    return sunrise.minus((long) Math.floor(adjustment), ChronoUnit.MINUTES);
+    return CalendricalHelper.add(sunrise, -(int) Math.floor(adjustment), Calendar.MINUTE);
   }
 
-  private static ZonedDateTime seasonAdjustedIsha(
-      double latitude, int day, int year, ZonedDateTime sunset) {
+  private static Date seasonAdjustedIsha(double latitude, int day, int year, Date sunset) {
     final double a = 75 + ((25.60 / 55.0) * Math.abs(latitude));
     final double b = 75 + ((2.050 / 55.0) * Math.abs(latitude));
     final double c = 75 - ((9.210 / 55.0) * Math.abs(latitude));
@@ -217,13 +211,13 @@ public class PrayerTimes {
       adjustment = b + ( a - b ) / 91.0 * ( dyy - 275 );
     }
 
-    return sunset.plus((long) Math.ceil(adjustment), ChronoUnit.MINUTES);
+    return CalendricalHelper.add(sunset, (int) Math.ceil(adjustment), Calendar.MINUTE);
   }
 
   static int daysSinceSolstice(int dayOfYear, int year, double latitude) {
-    int daysSinceSolistice = 0;
+    int daysSinceSolistice;
     final int northernOffset = 10;
-    boolean isLeapYear = Year.isLeap(year);
+    boolean isLeapYear = CalendricalHelper.isLeapYear(year);
     final int southernOffset = isLeapYear ? 173 : 172;
     final int daysInYear = isLeapYear ? 366 : 365;
 

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/CalendricalHelper.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/CalendricalHelper.java
@@ -1,9 +1,9 @@
 package com.batoulapps.adhan.internal;
 
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.Year;
-import org.threeten.bp.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 public class CalendricalHelper {
 
@@ -20,22 +20,15 @@ public class CalendricalHelper {
 
   /**
    * The Julian Day for a given date
-   * @param localDate the date
+   * @param date the date
    * @return the julian day
    */
-  static double julianDay(LocalDate localDate) {
-    return julianDay(localDate.getYear(),
-        localDate.getMonthValue(), localDate.getDayOfMonth(), 0.0);
-  }
-
-  /**
-   * The Julian Day for a given date and time
-   * @param localDateTime the date and time
-   * @return the julian day
-   */
-  static double julianDay(LocalDateTime localDateTime) {
-    return julianDay(localDateTime.getYear(), localDateTime.getMonthValue(),
-        localDateTime.getDayOfMonth(), localDateTime.getHour() + localDateTime.getMinute() / 60.0);
+  static double julianDay(Date date) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(date);
+    return julianDay(calendar.get(Calendar.YEAR),
+        calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH),
+        calendar.get(Calendar.HOUR_OF_DAY) + calendar.get(Calendar.MINUTE) / 60.0);
   }
 
   /**
@@ -78,19 +71,60 @@ public class CalendricalHelper {
    * @param year the year
    * @return whether or not its a leap year
    */
-  static boolean isLeapYear(int year) {
-    return Year.isLeap(year);
+  public static boolean isLeapYear(int year) {
+    return year % 4 == 0 && !(year % 100 == 0 && year % 400 != 0);
   }
 
   /**
-   * Zoned date and time with a rounded minute
+   * Date and time with a rounded minute
    * This returns a date with the seconds rounded and added to the minute
    * @param when the date and time
    * @return the date and time with 0 seconds and minutes including rounded seconds
    */
-  public static ZonedDateTime roundedMinute(ZonedDateTime when) {
-    final double minute = when.getMinute();
-    final double second = when.getSecond();
-    return when.withMinute((int) (minute + Math.round(second / 60))).withSecond(0);
+  public static Date roundedMinute(Date when) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(when);
+    double minute = calendar.get(Calendar.MINUTE);
+    double second = calendar.get(Calendar.SECOND);
+    calendar.set(Calendar.MINUTE, (int) (minute + Math.round(second / 60)));
+    calendar.set(Calendar.SECOND, 0);
+    return calendar.getTime();
+  }
+
+  /**
+   * Gets a date for the particular date
+   * @param year the year
+   * @param month the month
+   * @param day the day
+   * @return the date with a time set to 00:00:00 at utc
+   */
+  public static Date resolveTime(int year, int month, int day) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    //noinspection MagicConstant
+    calendar.set(year, month - 1, day, 0, 0, 0);
+    return calendar.getTime();
+  }
+
+  /**
+   * Gets a date for the particular date
+   * @param components the date components
+   * @return the date with a time set to 00:00:00 at utc
+   */
+  public static Date resolveTime(DateComponents components) {
+    return resolveTime(components.year, components.month, components.day);
+  }
+
+  /**
+   * Add an offset to a particular day
+   * @param when the original date
+   * @param amount the amount to add
+   * @param field the field to add it to (from {@link java.util.Calendar}'s fields).
+   * @return the date with the offset added
+   */
+  public static Date add(Date when, int amount, int field) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(when);
+    calendar.add(field, amount);
+    return calendar.getTime();
   }
 }

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/DateComponents.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/DateComponents.java
@@ -1,0 +1,13 @@
+package com.batoulapps.adhan.internal;
+
+public class DateComponents {
+  public final int year;
+  public final int month;
+  public final int day;
+
+  public DateComponents(int year, int month, int day) {
+    this.year = year;
+    this.month = month;
+    this.day = day;
+  }
+}

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/SolarTime.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/SolarTime.java
@@ -3,26 +3,32 @@ package com.batoulapps.adhan.internal;
 import com.batoulapps.adhan.Coordinates;
 import com.batoulapps.adhan.ShadowLength;
 
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.temporal.ChronoUnit;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 public class SolarTime {
 
-  final LocalDate date;
-  final Coordinates observer;
-  final SolarCoordinates solar;
   public final double transit;
   public final double sunrise;
   public final double sunset;
 
+  private final Coordinates observer;
+  private final SolarCoordinates solar;
   private final SolarCoordinates prevSolar;
   private final SolarCoordinates nextSolar;
   private double approximateTransit;
 
-  public SolarTime(LocalDate date, Coordinates coordinates) {
-    final LocalDate today = LocalDate.from(date);
-    final LocalDate tomorrow = today.plus(1, ChronoUnit.DAYS);
-    final LocalDate yesterday = today.minus(1, ChronoUnit.DAYS);
+  public SolarTime(Date today, Coordinates coordinates) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(today);
+
+    calendar.add(Calendar.DATE, 1);
+    final Date tomorrow = calendar.getTime();
+
+    calendar.add(Calendar.DATE, -2);
+    final Date yesterday = calendar.getTime();
 
     this.prevSolar = new SolarCoordinates(CalendricalHelper.julianDay(yesterday));
     this.solar = new SolarCoordinates(CalendricalHelper.julianDay(today));
@@ -32,7 +38,6 @@ public class SolarTime {
         solar.apparentSiderealTime, solar.rightAscension);
     final double solarAltitude = -50.0 / 60.0;
 
-    this.date = date;
     this.observer = coordinates;
     this.transit = Astronomical.correctedTransit(this.approximateTransit, coordinates.longitude,
         solar.apparentSiderealTime, solar.rightAscension, prevSolar.rightAscension,

--- a/java/adhan/src/main/java/com/batoulapps/adhan/internal/TimeComponents.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/internal/TimeComponents.java
@@ -1,8 +1,9 @@
 package com.batoulapps.adhan.internal;
 
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.LocalTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 public class TimeComponents {
   final int hours;
@@ -15,13 +16,13 @@ public class TimeComponents {
     this.seconds = seconds;
   }
 
-  public LocalDateTime dateComponents(LocalDate date) {
-    if (hours < 24) {
-      LocalTime time = LocalTime.of(hours, minutes, seconds);
-      return LocalDateTime.of(date, time);
-    } else {
-      return LocalDateTime.of(date.getYear(), date.getMonth(), date.getDayOfMonth(),
-          23, minutes, seconds).plusHours(hours - 23);
-    }
+  public Date dateComponents(Date date) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(date);
+    calendar.set(Calendar.HOUR_OF_DAY, 0);
+    calendar.set(Calendar.MINUTE, minutes);
+    calendar.set(Calendar.SECOND, seconds);
+    calendar.add(Calendar.HOUR_OF_DAY, hours);
+    return calendar.getTime();
   }
 }

--- a/java/adhan/src/test/java/com/batoulapps/adhan/PrayerTimesTest.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/PrayerTimesTest.java
@@ -1,9 +1,13 @@
 package com.batoulapps.adhan;
 
+import com.batoulapps.adhan.internal.DateComponents;
+import com.batoulapps.adhan.internal.TestUtils;
+
 import org.junit.Test;
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.format.DateTimeFormatter;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -32,22 +36,22 @@ public class PrayerTimesTest {
     // (DYY=0 for December 21, and counting forward, DYY=11 for January 1 and so on).
     // For Southern Hemisphere start from June 21
     // (DYY=0 for June 21, and counting forward)
-    LocalDate date = LocalDate.of(year, month, day);
-    int dayOfYear = date.getDayOfYear();
+    Date date = TestUtils.makeDate(year, month, day);
+    int dayOfYear = TestUtils.getDayOfYear(date);
     assertThat(PrayerTimes.daysSinceSolstice(dayOfYear, date.getYear(), latitude)).isEqualTo(value);
   }
 
   @Test
   public void testPrayerTimes() {
-    LocalDate date = LocalDate.of(2015, 7, 12);
+    DateComponents date = new DateComponents(2015, 7, 12);
     CalculationParameters params = CalculationMethod.NORTH_AMERICA.getParameters();
     params.madhab = Madhab.HANAFI;
 
     Coordinates coordinates = new Coordinates(35.7750, -78.6336);
     PrayerTimes prayerTimes = new PrayerTimes(coordinates, date, params);
 
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm a")
-        .withZone(ZoneId.of("America/New_York"));
+    SimpleDateFormat formatter = new SimpleDateFormat("hh:mm a");
+    formatter.setTimeZone(TimeZone.getTimeZone("America/New_York"));
 
     assertThat(prayerTimes.fajr).isNotNull();
     assertThat(prayerTimes.sunrise).isNotNull();
@@ -56,21 +60,21 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("04:42 AM");
-    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("06:08 AM");
-    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("01:21 PM");
-    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("06:22 PM");
-    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("08:32 PM");
-    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("09:57 PM");
+    assertThat(formatter.format(prayerTimes.fajr)).isEqualTo("04:42 AM");
+    assertThat(formatter.format(prayerTimes.sunrise)).isEqualTo("06:08 AM");
+    assertThat(formatter.format(prayerTimes.dhuhr)).isEqualTo("01:21 PM");
+    assertThat(formatter.format(prayerTimes.asr)).isEqualTo("06:22 PM");
+    assertThat(formatter.format(prayerTimes.maghrib)).isEqualTo("08:32 PM");
+    assertThat(formatter.format(prayerTimes.isha)).isEqualTo("09:57 PM");
   }
 
   @Test
   public void testOffsets() {
-    LocalDate date = LocalDate.of(2015, 12, 1);
+    DateComponents date = new DateComponents(2015, 12, 1);
     Coordinates coordinates = new Coordinates(35.7750, -78.6336);
 
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm a")
-        .withZone(ZoneId.of("America/New_York"));
+    SimpleDateFormat formatter = new SimpleDateFormat("hh:mm a");
+    formatter.setTimeZone(TimeZone.getTimeZone("America/New_York"));
     CalculationParameters parameters = CalculationMethod.MUSLIM_WORLD_LEAGUE.getParameters();
 
     PrayerTimes prayerTimes = new PrayerTimes(coordinates, date, parameters);
@@ -81,12 +85,12 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("05:35 AM");
-    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("07:06 AM");
-    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("12:05 PM");
-    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("02:42 PM");
-    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("05:01 PM");
-    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("06:26 PM");
+    assertThat(formatter.format(prayerTimes.fajr)).isEqualTo("05:35 AM");
+    assertThat(formatter.format(prayerTimes.sunrise)).isEqualTo("07:06 AM");
+    assertThat(formatter.format(prayerTimes.dhuhr)).isEqualTo("12:05 PM");
+    assertThat(formatter.format(prayerTimes.asr)).isEqualTo("02:42 PM");
+    assertThat(formatter.format(prayerTimes.maghrib)).isEqualTo("05:01 PM");
+    assertThat(formatter.format(prayerTimes.isha)).isEqualTo("06:26 PM");
 
     parameters.adjustments.fajr = 10;
     parameters.adjustments.sunrise = 10;
@@ -103,12 +107,12 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("05:45 AM");
-    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("07:16 AM");
-    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("12:15 PM");
-    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("02:52 PM");
-    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("05:11 PM");
-    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("06:36 PM");
+    assertThat(formatter.format(prayerTimes.fajr)).isEqualTo("05:45 AM");
+    assertThat(formatter.format(prayerTimes.sunrise)).isEqualTo("07:16 AM");
+    assertThat(formatter.format(prayerTimes.dhuhr)).isEqualTo("12:15 PM");
+    assertThat(formatter.format(prayerTimes.asr)).isEqualTo("02:52 PM");
+    assertThat(formatter.format(prayerTimes.maghrib)).isEqualTo("05:11 PM");
+    assertThat(formatter.format(prayerTimes.isha)).isEqualTo("06:36 PM");
 
     parameters.adjustments = new PrayerAdjustments();
     prayerTimes = new PrayerTimes(coordinates, date, parameters);
@@ -119,23 +123,23 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("05:35 AM");
-    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("07:06 AM");
-    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("12:05 PM");
-    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("02:42 PM");
-    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("05:01 PM");
-    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("06:26 PM");
+    assertThat(formatter.format(prayerTimes.fajr)).isEqualTo("05:35 AM");
+    assertThat(formatter.format(prayerTimes.sunrise)).isEqualTo("07:06 AM");
+    assertThat(formatter.format(prayerTimes.dhuhr)).isEqualTo("12:05 PM");
+    assertThat(formatter.format(prayerTimes.asr)).isEqualTo("02:42 PM");
+    assertThat(formatter.format(prayerTimes.maghrib)).isEqualTo("05:01 PM");
+    assertThat(formatter.format(prayerTimes.isha)).isEqualTo("06:26 PM");
   }
 
   @Test
   public void testMoonsightingMethod() {
-    LocalDate date = LocalDate.of(2016, 1, 31);
+    DateComponents date = new DateComponents(2016, 1, 31);
     Coordinates coordinates = new Coordinates(35.7750, -78.6336);
     PrayerTimes prayerTimes = new PrayerTimes(
         coordinates, date, CalculationMethod.MOON_SIGHTING_COMMITTEE.getParameters());
 
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("hh:mm a")
-        .withZone(ZoneId.of("America/New_York"));
+    SimpleDateFormat formatter = new SimpleDateFormat("hh:mm a");
+    formatter.setTimeZone(TimeZone.getTimeZone("America/New_York"));
 
     assertThat(prayerTimes.fajr).isNotNull();
     assertThat(prayerTimes.sunrise).isNotNull();
@@ -144,11 +148,11 @@ public class PrayerTimesTest {
     assertThat(prayerTimes.maghrib).isNotNull();
     assertThat(prayerTimes.isha).isNotNull();
 
-    assertThat(prayerTimes.fajr.format(formatter)).isEqualTo("05:48 AM");
-    assertThat(prayerTimes.sunrise.format(formatter)).isEqualTo("07:16 AM");
-    assertThat(prayerTimes.dhuhr.format(formatter)).isEqualTo("12:33 PM");
-    assertThat(prayerTimes.asr.format(formatter)).isEqualTo("03:20 PM");
-    assertThat(prayerTimes.maghrib.format(formatter)).isEqualTo("05:43 PM");
-    assertThat(prayerTimes.isha.format(formatter)).isEqualTo("07:05 PM");
+    assertThat(formatter.format(prayerTimes.fajr)).isEqualTo("05:48 AM");
+    assertThat(formatter.format(prayerTimes.sunrise)).isEqualTo("07:16 AM");
+    assertThat(formatter.format(prayerTimes.dhuhr)).isEqualTo("12:33 PM");
+    assertThat(formatter.format(prayerTimes.asr)).isEqualTo("03:20 PM");
+    assertThat(formatter.format(prayerTimes.maghrib)).isEqualTo("05:43 PM");
+    assertThat(formatter.format(prayerTimes.isha)).isEqualTo("07:05 PM");
   }
 }

--- a/java/adhan/src/test/java/com/batoulapps/adhan/internal/AstronomicalTest.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/internal/AstronomicalTest.java
@@ -3,10 +3,9 @@ package com.batoulapps.adhan.internal;
 import com.batoulapps.adhan.Coordinates;
 
 import org.junit.Test;
-import org.threeten.bp.LocalDate;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.temporal.ChronoUnit;
 
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -93,7 +92,8 @@ public class AstronomicalTest {
     SolarTime previousTime = null;
     final Coordinates coordinates = new Coordinates(35 + 47.0/60.0, -78 - 39.0/60.0);
     for (int i = 0; i < 365; i++) {
-      SolarTime time = new SolarTime(LocalDate.of(2016, 1, 1).plus(i, ChronoUnit.DAYS), coordinates);
+      SolarTime time = new SolarTime(
+          TestUtils.makeDateWithOffset(2016, 1, 1, i, Calendar.DAY_OF_YEAR), coordinates);
       if (i > 0) {
         // transit from one day to another should not differ more than one minute
         assertThat(Math.abs(time.transit - previousTime.transit)).isLessThan(1.0/60.0);
@@ -157,7 +157,7 @@ public class AstronomicalTest {
      */
 
     final Coordinates coordinates = new Coordinates(35 + 47.0/60.0, -78 - 39.0/60.0);
-    final SolarTime solar = new SolarTime(LocalDate.of(2015, 7, 12), coordinates);
+    final SolarTime solar = new SolarTime(TestUtils.makeDate(2015, 7, 12), coordinates);
 
     final double transit = solar.transit;
     final double sunrise = solar.sunrise;
@@ -188,8 +188,8 @@ public class AstronomicalTest {
     // generated from http://aa.usno.navy.mil/data/docs/RS_OneYear.php for KUKUIHAELE, HAWAII
     final Coordinates coordinates = new Coordinates(
         /* latitude */ 20 + 7.0/60.0, /* longitude */ -155.0 - 34.0/60.0);
-    final SolarTime day1solar = new SolarTime(LocalDate.of(2015, 4, /* day */ 2), coordinates);
-    final SolarTime day2solar = new SolarTime(LocalDate.of(2015, 4, 3), coordinates);
+    final SolarTime day1solar = new SolarTime(TestUtils.makeDate(2015, 4, /* day */ 2), coordinates);
+    final SolarTime day2solar = new SolarTime(TestUtils.makeDate(2015, 4, 3), coordinates);
 
     final double day1 = day1solar.sunrise;
     final double day2 = day2solar.sunrise;
@@ -257,7 +257,7 @@ public class AstronomicalTest {
         CalendricalHelper.julianDay(/* year */ 2015, /* month */ 7, /* day */ 12, /* hours */ 4.25))
         .isWithin(0.000001).of(jdVal);
 
-    LocalDateTime components = LocalDateTime.of(/* year */ 2015, /* month */ 7, /* day */ 12,
+    Date components = TestUtils.makeDate(/* year */ 2015, /* month */ 7, /* day */ 12,
         /* hour */ 4, /* minute */ 15);
     assertThat(CalendricalHelper.julianDay(components)).isWithin(0.000001).of(jdVal);
 

--- a/java/adhan/src/test/java/com/batoulapps/adhan/internal/MathTest.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/internal/MathTest.java
@@ -1,9 +1,10 @@
 package com.batoulapps.adhan.internal;
 
 import org.junit.Test;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -85,16 +86,18 @@ public class MathTest {
 
   @Test
   public void testMinuteRounding() {
-    final ZonedDateTime comps1 =
-        ZonedDateTime.of(LocalDateTime.of(2015, 1, 1, 10, 2, 29), ZoneId.of("GMT"));
-    final ZonedDateTime rounded1 = CalendricalHelper.roundedMinute(comps1);
-    assertThat(rounded1.getMinute()).isEqualTo(2);
-    assertThat(rounded1.getSecond()).isEqualTo(0);
+    final Date comps1 = TestUtils.makeDate(2015, 1, 1, 10, 2, 29);
+    final Date rounded1 = CalendricalHelper.roundedMinute(comps1);
 
-    final ZonedDateTime comps2 =
-        ZonedDateTime.of(LocalDateTime.of(2015, 1, 1, 10, 2, 31), ZoneId.of("GMT"));
-    final ZonedDateTime rounded2 = CalendricalHelper.roundedMinute(comps2);
-    assertThat(rounded2.getMinute()).isEqualTo(3);
-    assertThat(rounded2.getSecond()).isEqualTo(0);
+    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(rounded1);
+    assertThat(calendar.get(Calendar.MINUTE)).isEqualTo(2);
+    assertThat(calendar.get(Calendar.SECOND)).isEqualTo(0);
+
+    final Date comps2 = TestUtils.makeDate(2015, 1, 1, 10, 2, 31);
+    final Date rounded2 = CalendricalHelper.roundedMinute(comps2);
+    calendar.setTime(rounded2);
+    assertThat(calendar.get(Calendar.MINUTE)).isEqualTo(3);
+    assertThat(calendar.get(Calendar.SECOND)).isEqualTo(0);
   }
 }

--- a/java/adhan/src/test/java/com/batoulapps/adhan/internal/TestUtils.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/internal/TestUtils.java
@@ -1,0 +1,38 @@
+package com.batoulapps.adhan.internal;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+public class TestUtils {
+
+  public static Date makeDate(int year, int month, int day) {
+    return makeDate(year, month, day, 0, 0, 0);
+  }
+
+  static Date makeDate(int year, int month, int day, int hour, int minute) {
+    return makeDate(year, month, day, hour, minute, 0);
+  }
+
+  static Date makeDate(int year, int month, int day, int hour, int minute, int second) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    //noinspection MagicConstant
+    calendar.set(year, month - 1, day, hour, minute, second);
+    return calendar.getTime();
+  }
+
+  public static int getDayOfYear(Date date) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(date);
+    return calendar.get(Calendar.DAY_OF_YEAR);
+  }
+
+  static Date makeDateWithOffset(int year, int month, int day, int offset, int unit) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    //noinspection MagicConstant
+    calendar.set(year, month - 1, day);
+    calendar.add(unit, offset);
+    return calendar.getTime();
+  }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -20,9 +20,6 @@
         <!-- compilation -->
         <java.version>1.7</java.version>
 
-        <!-- dependencies -->
-        <threeten.version>1.3.1</threeten.version>
-
         <!-- test dependencies -->
         <junit.version>4.12</junit.version>
         <truth.version>0.27</truth.version>
@@ -30,12 +27,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.threeten</groupId>
-                <artifactId>threetenbp</artifactId>
-                <version>${threeten.version}</version>
-            </dependency>
-
             <!-- test dependencies -->
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
The JSR310 backport api is definitely a better api than the Java 6
calendar apis. However, due to excessive caching with resource loading
on Android (used for loading the timezone database), an Android wrapper
would be ideally used, replacing the timezone provider with something
that reads from AssetManager.

Implementing this correctly in Adhan would have therefore required
splitting up this library into 3 modules - a core module, a library
module (for use by Java projects depending on threeten backport), and an
Android Android module (outputting an aar for use by Android projects
and  depending on the Android specific flavor of threeten backport).

Since this is a hassle and costs the developer ~3000 methods towards the
method limit, and since we don't really deal with timezone conversions
within the library (everything is done in UTC), the alternative was to
just use the java 6 apis. While more painful for the library developer,
this simplifies life for the application developers and allows them to
use whatever time library they want in their app (joda time, threeten
backport, or even native java 8 when not on Android).
