### PR TITLE
Add currentPrayer and nextPrayer methods to Java

### DIFF
--- a/java/adhan/src/main/java/com/batoulapps/adhan/Prayer.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/Prayer.java
@@ -1,0 +1,11 @@
+package com.batoulapps.adhan;
+
+public enum Prayer {
+  NONE,
+  FAJR,
+  SUNRISE,
+  DHUHR,
+  ASR,
+  MAGHRIB,
+  ISHA,
+}

--- a/java/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
@@ -178,6 +178,10 @@ public class PrayerTimes {
     }
   }
 
+  public Prayer currentPrayer() {
+    return currentPrayer(new Date());
+  }
+
   public Prayer currentPrayer(Date time) {
     long when = time.getTime();
     if (this.isha.getTime() - when <= 0) {
@@ -195,6 +199,10 @@ public class PrayerTimes {
     } else {
       return Prayer.NONE;
     }
+  }
+
+  public Prayer nextPrayer() {
+    return nextPrayer(new Date());
   }
 
   public Prayer nextPrayer(Date time) {

--- a/java/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
+++ b/java/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
@@ -178,6 +178,64 @@ public class PrayerTimes {
     }
   }
 
+  public Prayer currentPrayer(Date time) {
+    long when = time.getTime();
+    if (this.isha.getTime() - when <= 0) {
+      return Prayer.ISHA;
+    } else if (this.maghrib.getTime() - when <= 0) {
+      return Prayer.MAGHRIB;
+    } else if (this.asr.getTime() - when <= 0) {
+      return Prayer.ASR;
+    } else if (this.dhuhr.getTime() - when <= 0) {
+      return Prayer.DHUHR;
+    } else if (this.sunrise.getTime() - when <= 0) {
+      return Prayer.SUNRISE;
+    } else if (this.fajr.getTime() - when <= 0) {
+      return Prayer.FAJR;
+    } else {
+      return Prayer.NONE;
+    }
+  }
+
+  public Prayer nextPrayer(Date time) {
+    long when = time.getTime();
+    if (this.isha.getTime() - when <= 0) {
+      return Prayer.NONE;
+    } else if (this.maghrib.getTime() - when <= 0) {
+      return Prayer.ISHA;
+    } else if (this.asr.getTime() - when <= 0) {
+      return Prayer.MAGHRIB;
+    } else if (this.dhuhr.getTime() - when <= 0) {
+      return Prayer.ASR;
+    } else if (this.sunrise.getTime() - when <= 0) {
+      return Prayer.DHUHR;
+    } else if (this.fajr.getTime() - when <= 0) {
+      return Prayer.SUNRISE;
+    } else {
+      return Prayer.FAJR;
+    }
+  }
+
+  public Date timeForPrayer(Prayer prayer) {
+    switch (prayer) {
+      case FAJR:
+        return this.fajr;
+      case SUNRISE:
+        return this.sunrise;
+      case DHUHR:
+        return this.dhuhr;
+      case ASR:
+        return this.asr;
+      case MAGHRIB:
+        return this.maghrib;
+      case ISHA:
+        return this.isha;
+      case NONE:
+      default:
+        return null;
+    }
+  }
+
   private static Date seasonAdjustedMorningTwilight(
       double latitude, int day, int year, Date sunrise) {
     final double a = 75 + ((28.65 / 55.0) * Math.abs(latitude));

--- a/java/adhan/src/test/java/com/batoulapps/adhan/PrayerTimesTest.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/PrayerTimesTest.java
@@ -141,4 +141,62 @@ public class PrayerTimesTest {
     assertThat(formatter.format(prayerTimes.maghrib)).isEqualTo("03:25 PM");
     assertThat(formatter.format(prayerTimes.isha)).isEqualTo("05:02 PM");
   }
+
+  @Test
+  public void testTimeForPrayer() {
+    DateComponents components = new DateComponents(2016, 7, 1);
+    CalculationParameters parameters = CalculationMethod.MUSLIM_WORLD_LEAGUE.getParameters();
+    parameters.madhab = Madhab.HANAFI;
+    parameters.highLatitudeRule = HighLatitudeRule.TWILIGHT_ANGLE;
+    Coordinates coordinates = new Coordinates(59.9094, 10.7349);
+
+    PrayerTimes p = new PrayerTimes(coordinates, components, parameters);
+    assertThat(p.fajr).isEqualTo(p.timeForPrayer(Prayer.FAJR));
+    assertThat(p.sunrise).isEqualTo(p.timeForPrayer(Prayer.SUNRISE));
+    assertThat(p.dhuhr).isEqualTo(p.timeForPrayer(Prayer.DHUHR));
+    assertThat(p.asr).isEqualTo(p.timeForPrayer(Prayer.ASR));
+    assertThat(p.maghrib).isEqualTo(p.timeForPrayer(Prayer.MAGHRIB));
+    assertThat(p.isha).isEqualTo(p.timeForPrayer(Prayer.ISHA));
+    assertThat(p.timeForPrayer(Prayer.NONE)).isNull();
+  }
+
+  @Test
+  public void testCurrentPrayer() {
+    DateComponents components = new DateComponents(2015, 9, 1);
+    CalculationParameters parameters = CalculationMethod.KARACHI.getParameters();
+    parameters.madhab = Madhab.HANAFI;
+    parameters.highLatitudeRule = HighLatitudeRule.TWILIGHT_ANGLE;
+    Coordinates coordinates = new Coordinates(33.720817, 73.090032);
+
+    PrayerTimes p = new PrayerTimes(coordinates, components, parameters);
+
+    assertThat(p.currentPrayer(TestUtils.addSeconds(p.fajr, -1))).isEqualTo(Prayer.NONE);
+    assertThat(p.currentPrayer(p.fajr)).isEqualTo(Prayer.FAJR);
+    assertThat(p.currentPrayer(TestUtils.addSeconds(p.fajr, 1))).isEqualTo(Prayer.FAJR);
+    assertThat(p.currentPrayer(TestUtils.addSeconds(p.sunrise, 1))).isEqualTo(Prayer.SUNRISE);
+    assertThat(p.currentPrayer(TestUtils.addSeconds(p.dhuhr, 1))).isEqualTo(Prayer.DHUHR);
+    assertThat(p.currentPrayer(TestUtils.addSeconds(p.asr, 1))).isEqualTo(Prayer.ASR);
+    assertThat(p.currentPrayer(TestUtils.addSeconds(p.maghrib, 1))).isEqualTo(Prayer.MAGHRIB);
+    assertThat(p.currentPrayer(TestUtils.addSeconds(p.isha, 1))).isEqualTo(Prayer.ISHA);
+  }
+
+  @Test
+  public void testNextPrayer() {
+    DateComponents components = new DateComponents(2015, 9, 1);
+    CalculationParameters parameters = CalculationMethod.KARACHI.getParameters();
+    parameters.madhab = Madhab.HANAFI;
+    parameters.highLatitudeRule = HighLatitudeRule.TWILIGHT_ANGLE;
+    Coordinates coordinates = new Coordinates(33.720817, 73.090032);
+
+    PrayerTimes p = new PrayerTimes(coordinates, components, parameters);
+
+    assertThat(p.nextPrayer(TestUtils.addSeconds(p.fajr, -1))).isEqualTo(Prayer.FAJR);
+    assertThat(p.nextPrayer(p.fajr)).isEqualTo(Prayer.SUNRISE);
+    assertThat(p.nextPrayer(TestUtils.addSeconds(p.fajr, 1))).isEqualTo(Prayer.SUNRISE);
+    assertThat(p.nextPrayer(TestUtils.addSeconds(p.sunrise, 1))).isEqualTo(Prayer.DHUHR);
+    assertThat(p.nextPrayer(TestUtils.addSeconds(p.dhuhr, 1))).isEqualTo(Prayer.ASR);
+    assertThat(p.nextPrayer(TestUtils.addSeconds(p.asr, 1))).isEqualTo(Prayer.MAGHRIB);
+    assertThat(p.nextPrayer(TestUtils.addSeconds(p.maghrib, 1))).isEqualTo(Prayer.ISHA);
+    assertThat(p.nextPrayer(TestUtils.addSeconds(p.isha, 1))).isEqualTo(Prayer.NONE);
+  }
 }

--- a/java/adhan/src/test/java/com/batoulapps/adhan/internal/TestUtils.java
+++ b/java/adhan/src/test/java/com/batoulapps/adhan/internal/TestUtils.java
@@ -1,5 +1,6 @@
 package com.batoulapps.adhan.internal;
 
+import com.batoulapps.adhan.data.CalendarUtil;
 import com.batoulapps.adhan.data.DateComponents;
 
 import java.util.Calendar;
@@ -36,6 +37,10 @@ public class TestUtils {
     int month = Integer.parseInt(pieces[1]);
     int day = Integer.parseInt(pieces[2]);
     return new DateComponents(year, month, day);
+  }
+
+  public static Date addSeconds(Date date, int seconds) {
+    return CalendarUtil.add(date, seconds, Calendar.SECOND);
   }
 
   static Date makeDateWithOffset(int year, int month, int day, int offset, int unit) {


### PR DESCRIPTION
Adds three methods to the Java api for consistency with the Swift api:
- currentPrayer (returns the current prayer based on the date passed in)
- nextPrayer (returns the upcoming prayer based on the date passed in)
- timeForPrayer (returns the time of a particular prayer)
