### PR TITLE
Fix access control for coordinates initializer.

### DIFF
--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -44,6 +44,11 @@ public enum HighLatitudeRule {
 public struct Coordinates {
     let latitude: Double
     let longitude: Double
+        
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
 }
 
 /* Adjustment value for prayer times, in minutes */


### PR DESCRIPTION
Sorry! I messed up the access control for external module consumption :(

"As with the default initializer above, if you want a public structure type to be initializable with a memberwise initializer when used in another module, you must provide a public memberwise initializer yourself as part of the type’s definition."