### PR TITLE
Add qiyam-ul-layl to prayer times

### DIFF
--- a/Swift/Adhan.xcodeproj/project.pbxproj
+++ b/Swift/Adhan.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		84F8E13A1C7AB563004C48D7 /* Adhan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F8E1391C7AB563004C48D7 /* Adhan.swift */; };
 		84F8E13C1C7AB5DE004C48D7 /* AstronomicalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F8E13B1C7AB5DE004C48D7 /* AstronomicalTests.swift */; };
 		84F8E13E1C7AB635004C48D7 /* MathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F8E13D1C7AB635004C48D7 /* MathTests.swift */; };
+		8B9180A71EA9BF83004C9E52 /* SunnahTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9180A61EA9BF83004C9E52 /* SunnahTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		84F8E1391C7AB563004C48D7 /* Adhan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Adhan.swift; sourceTree = "<group>"; };
 		84F8E13B1C7AB5DE004C48D7 /* AstronomicalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AstronomicalTests.swift; sourceTree = "<group>"; };
 		84F8E13D1C7AB635004C48D7 /* MathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MathTests.swift; sourceTree = "<group>"; };
+		8B9180A61EA9BF83004C9E52 /* SunnahTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SunnahTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +106,7 @@
 				84F8E13B1C7AB5DE004C48D7 /* AstronomicalTests.swift */,
 				84F8E13D1C7AB635004C48D7 /* MathTests.swift */,
 				84482DBA1EA70A160074E53C /* QiblaTests.swift */,
+				8B9180A61EA9BF83004C9E52 /* SunnahTests.swift */,
 				8480CCD81CD2DE0F00BD380B /* ObjcTests.m */,
 				84F8E1301C7AB542004C48D7 /* Info.plist */,
 			);
@@ -235,6 +238,7 @@
 				84F8E13E1C7AB635004C48D7 /* MathTests.swift in Sources */,
 				84F8E12F1C7AB542004C48D7 /* AdhanTests.swift in Sources */,
 				8480CCD91CD2DE0F00BD380B /* ObjcTests.m in Sources */,
+				8B9180A71EA9BF83004C9E52 /* SunnahTests.swift in Sources */,
 				84F8E13C1C7AB5DE004C48D7 /* AstronomicalTests.swift in Sources */,
 				84482DBB1EA70A160074E53C /* QiblaTests.swift in Sources */,
 			);

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -194,7 +194,7 @@ public struct PrayerTimes {
         var tempAsr: Date? = nil
         var tempMaghrib: Date? = nil
         var tempIsha: Date? = nil
-        let cal: Calendar = .utcGregorian
+        let cal: Calendar = .gregorianUTC
         
         guard let prayerDate = cal.date(from: date) else {
             return nil
@@ -416,7 +416,7 @@ public struct SunnahTimes {
     public let lastThird: Date
 
     public init?(from prayerTimes: PrayerTimes) {
-        let cal: Calendar = .utcGregorian
+        let cal: Calendar = .gregorianUTC
         let tomorrow = cal.date(byAdding: .day, value: 1, to: prayerTimes.fajr)!
         
         guard let nextDayPrayers = PrayerTimes(
@@ -459,7 +459,7 @@ struct SolarTime {
         midnightDate.hour = 0
         midnightDate.minute = 0
         
-        let cal: Calendar = .utcGregorian
+        let cal: Calendar = .gregorianUTC
         let today = cal.date(from: date)!
         
         let tomorrow = cal.date(byAdding: .day, value: 1, to: today)!
@@ -868,7 +868,7 @@ struct TimeComponents {
 extension Calendar {
     
     /// All calculations are done using a gregorian calendar with the UTC timezone
-    static let utcGregorian: Calendar = {
+    static let gregorianUTC: Calendar = {
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = TimeZone(identifier: "UTC")!
         return cal
@@ -878,7 +878,7 @@ extension Calendar {
 extension Date {
     
     func roundedMinute() -> Date {
-        let cal: Calendar = .utcGregorian
+        let cal: Calendar = .gregorianUTC
         var components = cal.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self)
         
         let minute: Double = Double(components.minute ?? 0)

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -187,11 +187,7 @@ public struct PrayerTimes {
         let nextFajr = calendar.date(byAdding: .day, value: 1, to: fajr)!
         let minutes = calendar.dateComponents([.minute], from: maghrib, to: nextFajr).minute!
         let twoThirds = Double(minutes) * (2.0 / 3.0)
-        return calendar.date(
-            byAdding: .minute,
-            value: Int(twoThirds),
-            to: maghrib
-        )!
+        return calendar.date(byAdding: .minute, value: Int(twoThirds), to: maghrib)!
     }
 
     // All calculations are done using a gregorian calendar with the UTC timezone

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -427,12 +427,12 @@ public struct SunnahTimes {
                 return nil
         }
         
-        let seconds = cal.dateComponents([.second], from: prayerTimes.maghrib, to: nextDayPrayers.fajr).second!
+        let seconds = nextDayPrayers.fajr.timeIntervalSince1970 - prayerTimes.maghrib.timeIntervalSince1970
         
-        let half = Double(seconds) / 2.0
+        let half = seconds / 2.0
         self.middleOfTheNight = cal.date(byAdding: .second, value: Int(half), to: prayerTimes.maghrib)!
         
-        let twoThirds = Double(seconds) * (2.0 / 3.0)
+        let twoThirds = seconds * (2.0 / 3.0)
         self.lastThirdOfTheNight = cal.date(byAdding: .second, value: Int(twoThirds), to: prayerTimes.maghrib)!
     }
 }

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -415,7 +415,7 @@ public struct SunnahTimes {
     public let midnight: Date
     public let lastThird: Date
 
-    public init?(prayerTimes: PrayerTimes) {
+    public init?(from prayerTimes: PrayerTimes) {
         let cal: Calendar = .utcGregorian
         let tomorrow = cal.date(byAdding: .day, value: 1, to: prayerTimes.fajr)!
         

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -172,7 +172,7 @@ public enum CalculationMethod {
 }
 
 /* Prayer times for a location and date using the given calculation parameters.
-All prayer times are in UTC and should be display using an DateFormatter that
+All prayer times are in UTC and should be display using a DateFormatter that
 has the correct timezone set. */
 public struct PrayerTimes {
     public let fajr: Date
@@ -409,11 +409,11 @@ public struct Qibla {
 }
 
 /* Sunnah times for a location and date using the given prayer times.
-All prayer times are in UTC and should be display using an DateFormatter that
+All prayer times are in UTC and should be display using a DateFormatter that
 has the correct timezone set. */
 public struct SunnahTimes {
-    public let midnight: Date
-    public let lastThird: Date
+    public let middleOfTheNight: Date
+    public let lastThirdOfTheNight: Date
 
     public init?(from prayerTimes: PrayerTimes) {
         let cal: Calendar = .gregorianUTC
@@ -430,10 +430,10 @@ public struct SunnahTimes {
         let minutes = cal.dateComponents([.minute], from: prayerTimes.maghrib, to: nextDayPrayers.fajr).minute!
         
         let half = Double(minutes) / 2.0
-        self.midnight = cal.date(byAdding: .minute, value: Int(half), to: prayerTimes.maghrib)!
+        self.middleOfTheNight = cal.date(byAdding: .minute, value: Int(half), to: prayerTimes.maghrib)!
         
         let twoThirds = Double(minutes) * (2.0 / 3.0)
-        self.lastThird = cal.date(byAdding: .minute, value: Int(twoThirds), to: prayerTimes.maghrib)!
+        self.lastThirdOfTheNight = cal.date(byAdding: .minute, value: Int(twoThirds), to: prayerTimes.maghrib)!
     }
 }
 

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -430,10 +430,10 @@ public struct SunnahTimes {
         let seconds = nextDayPrayers.fajr.timeIntervalSince1970 - prayerTimes.maghrib.timeIntervalSince1970
         
         let half = seconds / 2.0
-        self.middleOfTheNight = cal.date(byAdding: .second, value: Int(half), to: prayerTimes.maghrib)!
+        self.middleOfTheNight = Date(timeIntervalSince1970: prayerTimes.maghrib.timeIntervalSince1970 + half)
         
         let twoThirds = seconds * (2.0 / 3.0)
-        self.lastThirdOfTheNight = cal.date(byAdding: .second, value: Int(twoThirds), to: prayerTimes.maghrib)!
+        self.lastThirdOfTheNight = Date(timeIntervalSince1970: prayerTimes.maghrib.timeIntervalSince1970 + twoThirds)
     }
 }
 

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -182,6 +182,25 @@ public struct PrayerTimes {
     public let maghrib: Date
     public let isha: Date
     
+    /// Qiyam-ul-layl for last third of the night
+    public var qiyam: Date {
+        let nextFajr = calendar.date(byAdding: .day, value: 1, to: fajr)!
+        let minutes = calendar.dateComponents([.minute], from: maghrib, to: nextFajr).minute!
+        let twoThirds = Double(minutes) * (2.0 / 3.0)
+        return calendar.date(
+            byAdding: .minute,
+            value: Int(twoThirds),
+            to: maghrib
+        )!
+    }
+
+    // All calculations are done using a gregorian calendar with the UTC timezone
+    private let calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+    
     public init?(coordinates: Coordinates, date: DateComponents, calculationParameters: CalculationParameters) {
         
         var tempFajr: Date? = nil
@@ -190,10 +209,7 @@ public struct PrayerTimes {
         var tempAsr: Date? = nil
         var tempMaghrib: Date? = nil
         var tempIsha: Date? = nil
-        
-        // all calculations are done using a gregorian calendar with the UTC timezone
-        var cal = Calendar(identifier: .gregorian)
-        cal.timeZone = TimeZone(identifier: "UTC")!
+        let cal = calendar
         
         guard let prayerDate = cal.date(from: date) else {
             return nil

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -427,13 +427,13 @@ public struct SunnahTimes {
                 return nil
         }
         
-        let minutes = cal.dateComponents([.minute], from: prayerTimes.maghrib, to: nextDayPrayers.fajr).minute!
+        let seconds = cal.dateComponents([.second], from: prayerTimes.maghrib, to: nextDayPrayers.fajr).second!
         
-        let half = Double(minutes) / 2.0
-        self.middleOfTheNight = cal.date(byAdding: .minute, value: Int(half), to: prayerTimes.maghrib)!
+        let half = Double(seconds) / 2.0
+        self.middleOfTheNight = cal.date(byAdding: .second, value: Int(half), to: prayerTimes.maghrib)!
         
-        let twoThirds = Double(minutes) * (2.0 / 3.0)
-        self.lastThirdOfTheNight = cal.date(byAdding: .minute, value: Int(twoThirds), to: prayerTimes.maghrib)!
+        let twoThirds = Double(seconds) * (2.0 / 3.0)
+        self.lastThirdOfTheNight = cal.date(byAdding: .second, value: Int(twoThirds), to: prayerTimes.maghrib)!
     }
 }
 

--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -427,13 +427,9 @@ public struct SunnahTimes {
                 return nil
         }
         
-        let seconds = nextDayPrayers.fajr.timeIntervalSince1970 - prayerTimes.maghrib.timeIntervalSince1970
-        
-        let half = seconds / 2.0
-        self.middleOfTheNight = Date(timeIntervalSince1970: prayerTimes.maghrib.timeIntervalSince1970 + half)
-        
-        let twoThirds = seconds * (2.0 / 3.0)
-        self.lastThirdOfTheNight = Date(timeIntervalSince1970: prayerTimes.maghrib.timeIntervalSince1970 + twoThirds)
+        let seconds = nextDayPrayers.fajr.timeIntervalSince(prayerTimes.maghrib)
+        self.middleOfTheNight = prayerTimes.maghrib.addingTimeInterval(seconds / 2)
+        self.lastThirdOfTheNight = prayerTimes.maghrib.addingTimeInterval(seconds * (2 / 3))
     }
 }
 

--- a/Swift/AdhanTests/AdhanTests.swift
+++ b/Swift/AdhanTests/AdhanTests.swift
@@ -144,7 +144,6 @@ class AdhanTests: XCTestCase {
         XCTAssertEqual(dateFormatter.string(from: p.asr), "6:22 PM")
         XCTAssertEqual(dateFormatter.string(from: p.maghrib), "8:32 PM")
         XCTAssertEqual(dateFormatter.string(from: p.isha), "9:57 PM")
-        XCTAssertEqual(dateFormatter.string(from: p.qiyam), "1:58 AM")
     }
     
     func testOffsets() {

--- a/Swift/AdhanTests/AdhanTests.swift
+++ b/Swift/AdhanTests/AdhanTests.swift
@@ -144,6 +144,7 @@ class AdhanTests: XCTestCase {
         XCTAssertEqual(dateFormatter.string(from: p.asr), "6:22 PM")
         XCTAssertEqual(dateFormatter.string(from: p.maghrib), "8:32 PM")
         XCTAssertEqual(dateFormatter.string(from: p.isha), "9:57 PM")
+        XCTAssertEqual(dateFormatter.string(from: p.qiyam), "1:58 AM")
     }
     
     func testOffsets() {

--- a/Swift/AdhanTests/SunnahTests.swift
+++ b/Swift/AdhanTests/SunnahTests.swift
@@ -38,7 +38,7 @@ class SunnahTests: XCTestCase {
         XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "4:43 AM")
         
         let sunnahTimes = SunnahTimes(from: todayPrayers)!
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.midnight), "12:37 AM")
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThird), "1:59 AM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "12:37 AM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "1:59 AM")
     }
 }

--- a/Swift/AdhanTests/SunnahTests.swift
+++ b/Swift/AdhanTests/SunnahTests.swift
@@ -1,0 +1,44 @@
+//
+//  SunnahTests.swift
+//  Adhan
+//
+//  Created by Basem Emara on 4/21/17.
+//  Copyright © 2017 Batoul Apps. All rights reserved.
+//
+
+import XCTest
+@testable import Adhan
+
+class SunnahTests: XCTestCase {
+    
+    func testSunnahTimes() {
+        var params = CalculationMethod.northAmerica.params
+        params.madhab = .hanafi
+        let coordinates = Coordinates(latitude: 35.7750, longitude: -78.6336)
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone(identifier: "America/New_York")!
+        dateFormatter.dateStyle = .none
+        dateFormatter.timeStyle = .short
+        
+        var comps1 = DateComponents()
+        comps1.year = 2015
+        comps1.month = 7
+        comps1.day = 12
+        
+        let todayPrayers = PrayerTimes(coordinates: coordinates, date: comps1, calculationParameters: params)!
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "8:32 PM")
+        
+        var comps2 = DateComponents()
+        comps2.year = 2015
+        comps2.month = 7
+        comps2.day = 13
+        
+        let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "4:43 AM")
+        
+        let sunnahTimes = SunnahTimes(prayerTimes: todayPrayers)!
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.midnight), "12:37 AM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThird), "1:59 AM")
+    }
+}

--- a/Swift/AdhanTests/SunnahTests.swift
+++ b/Swift/AdhanTests/SunnahTests.swift
@@ -14,11 +14,12 @@ class SunnahTests: XCTestCase {
     func testSunnahTimesNY() {
         var params = CalculationMethod.northAmerica.params
         params.madhab = .hanafi
+        params.highLatitudeRule = .middleOfTheNight
         let coordinates = Coordinates(latitude: 35.7750, longitude: -78.6336)
         
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(identifier: "America/New_York")!
-        dateFormatter.dateStyle = .none
+        dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
         
         var comps1 = DateComponents()
@@ -27,7 +28,7 @@ class SunnahTests: XCTestCase {
         comps1.day = 12
         
         let todayPrayers = PrayerTimes(coordinates: coordinates, date: comps1, calculationParameters: params)!
-        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "8:32 PM")
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "7/12/15, 8:32 PM")
         
         var comps2 = DateComponents()
         comps2.year = 2015
@@ -35,22 +36,22 @@ class SunnahTests: XCTestCase {
         comps2.day = 13
         
         let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
-        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "4:43 AM")
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "7/13/15, 4:43 AM")
         
         let sunnahTimes = SunnahTimes(from: todayPrayers)!
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "12:37 AM")
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "1:59 AM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "7/13/15, 12:37 AM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "7/13/15, 1:59 AM")
     }
     
     func testSunnahTimesLondon() {
         var params = CalculationMethod.muslimWorldLeague.params
-        params.madhab = .hanafi
+        params.madhab = .shafi
         params.highLatitudeRule = .twilightAngle
         let coordinates = Coordinates(latitude: 51.5074, longitude: -0.1278)
         
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(identifier: "Europe/London")!
-        dateFormatter.dateStyle = .none
+        dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
         
         var comps1 = DateComponents()
@@ -59,7 +60,7 @@ class SunnahTests: XCTestCase {
         comps1.day = 31
         
         let todayPrayers = PrayerTimes(coordinates: coordinates, date: comps1, calculationParameters: params)!
-        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "4:01 PM")
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "12/31/16, 4:01 PM")
         
         var comps2 = DateComponents()
         comps2.year = 2017
@@ -67,24 +68,21 @@ class SunnahTests: XCTestCase {
         comps2.day = 1
         
         let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
-        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "6:03 AM")
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "1/1/17, 6:03 AM")
         
         let sunnahTimes = SunnahTimes(from: todayPrayers)!
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "11:02 PM")
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "1:22 AM")
-        
-        // TODO: Verify above tests are correct
-        XCTFail()
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "12/31/16, 11:02 PM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "1/1/17, 1:22 AM")
     }
     
     func testSunnahTimesDST1() {
         var params = CalculationMethod.northAmerica.params
-        params.madhab = .shafi
+        params.madhab = .hanafi
         let coordinates = Coordinates(latitude: 37.7749, longitude: -122.4194)
         
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(identifier: "America/Los_Angeles")!
-        dateFormatter.dateStyle = .none
+        dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
         
         var comps1 = DateComponents()
@@ -93,7 +91,8 @@ class SunnahTests: XCTestCase {
         comps1.day = 11
         
         let todayPrayers = PrayerTimes(coordinates: coordinates, date: comps1, calculationParameters: params)!
-        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "6:13 PM")
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.fajr), "3/11/17, 5:14 AM")
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "3/11/17, 6:13 PM")
         
         var comps2 = DateComponents()
         comps2.year = 2017
@@ -101,24 +100,23 @@ class SunnahTests: XCTestCase {
         comps2.day = 12
         
         let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
-        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "6:13 AM")
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "3/12/17, 6:13 AM")
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.maghrib), "3/12/17, 7:14 PM")
         
         let sunnahTimes = SunnahTimes(from: todayPrayers)!
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "11:43 PM")
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "1:33 AM")
-        
-        // TODO: Verify above tests are correct
-        XCTFail()
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "3/11/17, 11:43 PM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "3/12/17, 1:33 AM")
     }
     
     func testSunnahTimesDST2() {
-        var params = CalculationMethod.northAmerica.params
+        var params = CalculationMethod.muslimWorldLeague.params
         params.madhab = .shafi
+        params.highLatitudeRule = .seventhOfTheNight
         let coordinates = Coordinates(latitude: 48.8566, longitude: 2.3522)
         
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(identifier: "Europe/Paris")!
-        dateFormatter.dateStyle = .none
+        dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
         
         var comps1 = DateComponents()
@@ -127,7 +125,8 @@ class SunnahTests: XCTestCase {
         comps1.day = 24
         
         let todayPrayers = PrayerTimes(coordinates: coordinates, date: comps1, calculationParameters: params)!
-        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "6:45 PM")
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.fajr), "10/24/15, 6:38 AM")
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "10/24/15, 6:45 PM")
         
         var comps2 = DateComponents()
         comps2.year = 2015
@@ -135,13 +134,11 @@ class SunnahTests: XCTestCase {
         comps2.day = 25
         
         let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
-        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "5:58 AM")
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "10/25/15, 5:40 AM")
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.maghrib), "10/25/15, 5:43 PM")
         
         let sunnahTimes = SunnahTimes(from: todayPrayers)!
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "12:51 AM")
-        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "2:53 AM")
-        
-        // TODO: Verify above tests are correct
-        XCTFail()
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "10/25/15, 12:42 AM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "10/25/15, 2:41 AM")
     }
 }

--- a/Swift/AdhanTests/SunnahTests.swift
+++ b/Swift/AdhanTests/SunnahTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class SunnahTests: XCTestCase {
     
-    func testSunnahTimes() {
+    func testSunnahTimesNY() {
         var params = CalculationMethod.northAmerica.params
         params.madhab = .hanafi
         let coordinates = Coordinates(latitude: 35.7750, longitude: -78.6336)
@@ -40,5 +40,108 @@ class SunnahTests: XCTestCase {
         let sunnahTimes = SunnahTimes(from: todayPrayers)!
         XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "12:37 AM")
         XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "1:59 AM")
+    }
+    
+    func testSunnahTimesLondon() {
+        var params = CalculationMethod.muslimWorldLeague.params
+        params.madhab = .hanafi
+        params.highLatitudeRule = .twilightAngle
+        let coordinates = Coordinates(latitude: 51.5074, longitude: -0.1278)
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone(identifier: "Europe/London")!
+        dateFormatter.dateStyle = .none
+        dateFormatter.timeStyle = .short
+        
+        var comps1 = DateComponents()
+        comps1.year = 2016
+        comps1.month = 12
+        comps1.day = 31
+        
+        let todayPrayers = PrayerTimes(coordinates: coordinates, date: comps1, calculationParameters: params)!
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "4:01 PM")
+        
+        var comps2 = DateComponents()
+        comps2.year = 2017
+        comps2.month = 1
+        comps2.day = 1
+        
+        let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "6:03 AM")
+        
+        let sunnahTimes = SunnahTimes(from: todayPrayers)!
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "11:02 PM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "1:22 AM")
+        
+        // TODO: Verify above tests are correct
+        XCTFail()
+    }
+    
+    func testSunnahTimesDST1() {
+        var params = CalculationMethod.northAmerica.params
+        params.madhab = .shafi
+        let coordinates = Coordinates(latitude: 37.7749, longitude: -122.4194)
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        dateFormatter.dateStyle = .none
+        dateFormatter.timeStyle = .short
+        
+        var comps1 = DateComponents()
+        comps1.year = 2017
+        comps1.month = 3
+        comps1.day = 11
+        
+        let todayPrayers = PrayerTimes(coordinates: coordinates, date: comps1, calculationParameters: params)!
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "6:13 PM")
+        
+        var comps2 = DateComponents()
+        comps2.year = 2017
+        comps2.month = 3
+        comps2.day = 12
+        
+        let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "6:13 AM")
+        
+        let sunnahTimes = SunnahTimes(from: todayPrayers)!
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "11:43 PM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "1:33 AM")
+        
+        // TODO: Verify above tests are correct
+        XCTFail()
+    }
+    
+    func testSunnahTimesDST2() {
+        var params = CalculationMethod.northAmerica.params
+        params.madhab = .shafi
+        let coordinates = Coordinates(latitude: 48.8566, longitude: 2.3522)
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone(identifier: "Europe/Paris")!
+        dateFormatter.dateStyle = .none
+        dateFormatter.timeStyle = .short
+        
+        var comps1 = DateComponents()
+        comps1.year = 2015
+        comps1.month = 10
+        comps1.day = 24
+        
+        let todayPrayers = PrayerTimes(coordinates: coordinates, date: comps1, calculationParameters: params)!
+        XCTAssertEqual(dateFormatter.string(from: todayPrayers.maghrib), "6:45 PM")
+        
+        var comps2 = DateComponents()
+        comps2.year = 2015
+        comps2.month = 10
+        comps2.day = 25
+        
+        let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
+        XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "5:58 AM")
+        
+        let sunnahTimes = SunnahTimes(from: todayPrayers)!
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.middleOfTheNight), "12:51 AM")
+        XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThirdOfTheNight), "2:53 AM")
+        
+        // TODO: Verify above tests are correct
+        XCTFail()
     }
 }

--- a/Swift/AdhanTests/SunnahTests.swift
+++ b/Swift/AdhanTests/SunnahTests.swift
@@ -37,7 +37,7 @@ class SunnahTests: XCTestCase {
         let tomorrowPrayers = PrayerTimes(coordinates: coordinates, date: comps2, calculationParameters: params)!
         XCTAssertEqual(dateFormatter.string(from: tomorrowPrayers.fajr), "4:43 AM")
         
-        let sunnahTimes = SunnahTimes(prayerTimes: todayPrayers)!
+        let sunnahTimes = SunnahTimes(from: todayPrayers)!
         XCTAssertEqual(dateFormatter.string(from: sunnahTimes.midnight), "12:37 AM")
         XCTAssertEqual(dateFormatter.string(from: sunnahTimes.lastThird), "1:59 AM")
     }


### PR DESCRIPTION
Added dynamic qiyam-ul-layl time. Using last third of the night between maghrib and fajr for calculation.

For increased accuracy, should re-calculate prayers for next day to retrieve precise next day fajr, but traded off for performance and code simplicity since precision is fractional difference. However, could be a problem if next day requires daylight saving change or leap day.

Open for suggestions and discussion.