### PR TITLE
Change Qibla public access control for direction property

### DIFF
--- a/Swift/Adhan/Adhan.swift
+++ b/Swift/Adhan/Adhan.swift
@@ -395,7 +395,7 @@ public struct PrayerTimes {
 
 public struct Qibla {
     /* The heading to the Qibla from True North */
-    let direction: Double
+    public let direction: Double
     
     public init(coordinates: Coordinates) {
         let makkah = Coordinates(latitude: 21.4225241, longitude: 39.8261818)


### PR DESCRIPTION
For access `direction` property when Adhan used as a module.